### PR TITLE
Fix schedule timezone not persisted, causing duplicate backups and wrong restore point timestamps

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,6 +44,9 @@ for i in {1..30}; do
     sleep 1
 done
 
+# Ensure MariaDB stores timestamps in UTC so TimeHelper::format() displays them correctly
+mysql -u root -e "SET GLOBAL time_zone = '+00:00';"
+
 # Start ClickHouse (catalog engine)
 echo "Starting ClickHouse..."
 if command -v clickhouse-server &>/dev/null; then

--- a/src/Controllers/BackupPlanController.php
+++ b/src/Controllers/BackupPlanController.php
@@ -132,6 +132,7 @@ class BackupPlanController extends Controller
                 'times' => $times ?: null,
                 'day_of_week' => $dayOfWeek,
                 'day_of_month' => $dayOfMonth,
+                'timezone' => $_SESSION['timezone'] ?? 'America/New_York',
                 'enabled' => $frequency === 'manual' ? 0 : 1,
                 'next_run' => $nextRun,
             ], 'backup_plan_id = ?', [$id]);

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -65,6 +65,22 @@ class ProfileController extends Controller
         if ($timezone && in_array($timezone, timezone_identifiers_list()) && $timezone !== $user['timezone']) {
             $this->db->update('users', ['timezone' => $timezone], 'id = ?', [$userId]);
             $_SESSION['timezone'] = $timezone;
+            // Also update the timezone on all schedules this user has access to,
+            // so that SchedulerService recalculates next_run in the correct timezone.
+            if (($_SESSION['user_role'] ?? '') === 'admin') {
+                // Admin has access to all agents — update every schedule.
+                $this->db->query("UPDATE schedules SET timezone = ?", [$timezone]);
+            } else {
+                // Regular users are linked to agents via user_agents.
+                $this->db->query(
+                    "UPDATE schedules s
+                     JOIN backup_plans bp ON bp.id = s.backup_plan_id
+                     JOIN user_agents ua ON ua.agent_id = bp.agent_id
+                     SET s.timezone = ?
+                     WHERE ua.user_id = ?",
+                    [$timezone, $userId]
+                );
+            }
             $this->flash('success', 'Timezone updated.');
         }
 


### PR DESCRIPTION
## Problem

This PR fixes three related timezone bugs that together cause two visible symptoms:

### Symptom 1 — Backups run twice per day instead of once
When a user configures a daily backup schedule (e.g. 11:00 AM), the backup runs at 11:00 AM as expected, but then runs again approximately 1–4 hours later depending on the offset between the user's timezone and `America/New_York`.

**Root cause:** There are two separate places in the codebase that calculate `next_run`:
1. `BackupPlanController::calculateNextRun()` — used when creating or editing a plan via the UI. This correctly uses `$_SESSION['timezone']` (the user's configured timezone).
2. `SchedulerService::calculateNextRun()` — used after each backup runs to schedule the next one. This reads `schedules.timezone` from the database.

The bug is that `BackupPlanController::update()` never included `timezone` in its `UPDATE` query. So when a plan was edited (or even just saved without changes), the `schedules.timezone` column retained its original value — which defaults to `America/New_York` per the migration in `014_schedule_timezone.sql`.

**The result:** The initial `next_run` is calculated correctly in the user's timezone, but after the first backup completes, `SchedulerService` recalculates `next_run` using `America/New_York`, shifting the next run by the difference between that timezone and the user's actual timezone.

### Symptom 2 — Changing timezone in `/profile` does not update existing schedules
When a user changes their timezone in the profile settings, only the `users` table was updated. The `schedules.timezone` column for all existing backup plans remained unchanged, so the drift described above persisted even after fixing the profile.

### Symptom 3 — Restore points listed with wrong timestamp (hours off)
In the restore points tab (`/clients/{id}?tab=restore`), backup timestamps were displayed several hours behind the actual execution time.

**Root cause:** `TimeHelper::format()` assumes all stored timestamps are in UTC and converts them to the user's display timezone. This works correctly for `backup_jobs.completed_at`, which is set explicitly via PHP's `date('Y-m-d H:i:s')` (PHP runs as UTC inside the container). However, `archives.created_at` uses `CURRENT_TIMESTAMP` (MySQL default), which follows **the MariaDB server's system timezone** — and that timezone is inherited from the Docker host OS at startup. On any host not running UTC (e.g. `America/Sao_Paulo`, `America/New_York`), `CURRENT_TIMESTAMP` stores local time while `TimeHelper` interprets it as UTC, resulting in a display offset equal to the host's UTC offset.

---

## Fix

1. **BackupPlanController.php**
Added `'timezone' => $_SESSION['timezone'] ?? 'America/New_York'` to the `UPDATE` statement in `update()`. This ensures that whenever a backup plan is saved via the UI, the `schedules.timezone` column is always kept in sync with the user's current timezone, so `SchedulerService` and `BackupPlanController` always agree on which timezone to use for scheduling.

2. **ProfileController.php**
After saving a new timezone to the `users` table, the fix now propagates that timezone to all schedules the user has access to:
* **Admin users:** All schedules in the system are updated (admins have global access, consistent with the rest of the codebase's `isAdmin()` pattern).
* **Regular users:** Only schedules belonging to agents linked to that user via `user_agents` are updated.

3. **entrypoint.sh**
Added `SET GLOBAL time_zone = '+00:00'` immediately after MariaDB finishes starting up. This forces MariaDB to store all `CURRENT_TIMESTAMP` values in UTC regardless of the Docker host's system timezone, making `archives.created_at` consistent with what `TimeHelper::format()` expects.

---

## Testing

Tested on a Docker host running `America/Sao_Paulo` (UTC-3) with the container timezone unset (inheriting host):

| Scenario | Before | After |
| :--- | :--- | :--- |
| **Daily backup at 11:00 AM** | Ran at 11:00 AM and again at 12:00 PM | Runs only at 11:00 AM, next run scheduled 24h later |
| **Changing timezone in `/profile`** | Existing schedule timezones unchanged | All schedules updated immediately |
| **Restore point timestamp** | Displayed 3 hours behind actual execution time | Displays the correct local time |