### PR TITLE
Increase ClickHouse thread pool and background, fix startup clickhous…

### DIFF
--- a/config/clickhouse-server-override.xml
+++ b/config/clickhouse-server-override.xml
@@ -13,13 +13,13 @@
     </logger>
 
     <!-- Limit thread pools — BBS uses ClickHouse lightly (catalog storage) -->
-    <max_thread_pool_size>32</max_thread_pool_size>
+    <max_thread_pool_size>64</max_thread_pool_size>
     <max_thread_pool_free_size>4</max_thread_pool_free_size>
-    <background_pool_size>2</background_pool_size>
+    <background_pool_size>8</background_pool_size>
     <background_merges_mutations_concurrency_ratio>1</background_merges_mutations_concurrency_ratio>
     <background_move_pool_size>1</background_move_pool_size>
-    <background_schedule_pool_size>2</background_schedule_pool_size>
-    <background_common_pool_size>2</background_common_pool_size>
+    <background_schedule_pool_size>128</background_schedule_pool_size>
+    <background_common_pool_size>8</background_common_pool_size>
     <background_fetches_pool_size>1</background_fetches_pool_size>
 
     <!-- Disable system log tables that generate heavy disk I/O when idle -->


### PR DESCRIPTION

<!-- Brief description of what this PR does and why -->

## Changes
This pull request increases the concurrency and capacity of various ClickHouse server thread and background, the limits  were to low to server to startup.  Fix issue #88 and related to #83.

Resource allocation increases:

* Increased `max_thread_pool_size` from 32 to 64 to allow more concurrent threads.
* Increased `background_pool_size` from 2 to 8 to support more background tasks.
* Increased `background_schedule_pool_size` from 2 to 128 to allow significantly more scheduled background operations.
* Increased `background_common_pool_size` from 2 to 8 for general background task capacity.

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [ ] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows
