### PR TITLE
feat: add PUID/PGID support for Docker bind mount permission compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,9 @@ CLAUDE.md
 __pycache__
 *.pyc
 config/.env
+docker-compose.yml
+.env
+.env.example
+README.md
+LICENSE
+docs/

--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,12 @@ WEB_PORT=8080
 # SSH port for borg agent connections (host side)
 SSH_PORT=2222
 
+# Map container user to your host user's UID/GID. Required when using bind mounts
+# to avoid permission issues — especially on btrfs filesystems (e.g. Synology NAS).
+# Find your values with: id -u && id -g
+# Defaults to 33 (www-data) if not set.
+# PUID=1000
+# PGID=1000
+
 # Admin password — only used on first run. Remove or leave blank to auto-generate.
 # ADMIN_PASS=changeme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.4-apache
 
-# Install system dependencies, apply security patches, and clean up in one layer
+# Install system dependencies, apply security patches and clean up in one layer
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM php:8.4-apache
 
-# Install system dependencies and apply security patches
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+# Install system dependencies, apply security patches, and clean up in one layer
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     git \
     curl \
+    ca-certificates \
     libpng-dev \
     libonig-dev \
     libxml2-dev \
@@ -20,7 +21,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     openssh-server \
     python3-pip \
     gnupg \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install rclone from official binary (Debian package ships with outdated Go runtime)
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -28,25 +29,24 @@ RUN ARCH=$(dpkg --print-architecture) && \
     unzip -q /tmp/rclone.zip -d /tmp && \
     cp /tmp/rclone-*/rclone /usr/bin/rclone && \
     chmod 755 /usr/bin/rclone && \
-    rm -rf /tmp/rclone*
+    rm -rf /tmp/*
 
-# Install ClickHouse (catalog engine)
+# Install ClickHouse (catalog engine) and clean up in one layer
 RUN ARCH=$(dpkg --print-architecture) && \
     curl -fsSL -A 'Mozilla/5.0' 'https://packages.clickhouse.com/rpm/lts/repodata/repomd.xml.key' | \
         gpg --dearmor -o /usr/share/keyrings/clickhouse-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg arch=${ARCH}] https://packages.clickhouse.com/deb stable main" \
         > /etc/apt/sources.list.d/clickhouse.list && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server clickhouse-client && \
-    rm -rf /var/lib/apt/lists/*
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends clickhouse-server clickhouse-client && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Disable ClickHouse system log tables (heavy idle disk I/O)
 COPY config/clickhouse-server-override.xml /etc/clickhouse-server/config.d/bbs-override.xml
 
-# Install Apprise (notification tool supporting 100+ services)
-RUN pip3 install --break-system-packages --no-cache-dir apprise && \
-    rm -rf /usr/lib/python3/dist-packages/wheel* && \
-    pip3 install --break-system-packages --no-cache-dir wheel>=0.46.2
+# Install Apprise and wheel in a single pip call to avoid cache between calls
+RUN pip3 install --break-system-packages --no-cache-dir apprise wheel>=0.46.2 && \
+    rm -rf /root/.cache /usr/lib/python3/dist-packages/wheel*
 
 # Install PHP extensions
 RUN docker-php-ext-install pdo pdo_mysql mbstring
@@ -58,14 +58,10 @@ RUN echo "max_execution_time = 300" > /usr/local/etc/php/conf.d/bbs.ini
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# Enable Apache modules
-RUN a2enmod rewrite
-
-# Configure Apache
-RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
-
-# Apache vhost configuration
-RUN echo '<VirtualHost *:80>\n\
+# Enable Apache modules and configure in one layer
+RUN a2enmod rewrite && \
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
+    echo '<VirtualHost *:80>\n\
     DocumentRoot /var/www/bbs/public\n\
     <Directory /var/www/bbs/public>\n\
         AllowOverride All\n\
@@ -85,10 +81,11 @@ RUN mkdir -p /var/www/bbs /var/bbs/home /var/bbs/backups /var/bbs/cache /run/mys
     && chown -R www-data:www-data /var/www/bbs /var/bbs \
     && chown mysql:mysql /run/mysqld
 
-# Copy application code and install dependencies
+# Copy application code, install dependencies, and clean up in one layer
 COPY . /var/www/bbs/
-RUN cd /var/www/bbs && composer install --no-dev --optimize-autoloader --no-interaction --quiet
-RUN chown -R www-data:www-data /var/www/bbs
+RUN cd /var/www/bbs && composer install --no-dev --optimize-autoloader --no-interaction --quiet \
+    && rm -rf /root/.composer/cache \
+    && chown -R www-data:www-data /var/www/bbs
 
 # Install SSH helper and gate
 RUN cp /var/www/bbs/bin/bbs-ssh-helper /usr/local/bin/bbs-ssh-helper \
@@ -103,6 +100,10 @@ RUN echo "www-data ALL=(root) NOPASSWD: /usr/local/bin/bbs-ssh-helper, /var/www/
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+
+# Support custom UID/GID mapping for bind mounts
+ENV PUID=33
+ENV PGID=33
 
 EXPOSE 80 22
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,16 @@ services:
     # build: .    # uncomment to build locally instead of pulling from Docker Hub
     container_name: bbs
     ports:
-      - "${WEB_PORT:-8080}:80"      # Web UI
-      - "${SSH_PORT:-2222}:22"      # SSH for borg agent connections
+      - "${WEB_PORT:-8080}:80" # Web UI
+      - "${SSH_PORT:-2222}:22" # SSH for borg agent connections
     environment:
       - APP_URL=${APP_URL:-http://localhost:8080}
       - SSH_PORT=${SSH_PORT:-2222}
+      # Map container user to your host user's UID/GID. Fixes permission issues
+      # with bind mounts, especially on btrfs filesystems (e.g. Synology NAS).
+      # Find your values with: id -u && id -g
+      # - PUID=${PUID:-33}
+      # - PGID=${PGID:-33}
       # Admin password — only used on first run. Omit to auto-generate (shown in logs).
       # - ADMIN_PASS=${ADMIN_PASS}
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,61 @@ set -e
 echo "=== BBS Container Starting ==="
 echo "Version: $(cat /var/www/bbs/VERSION 2>/dev/null || echo 'unknown')"
 
+# --- Helper: ensure directory exists with correct owner and permissions ---
+ensure_dir() {
+    local dir="$1" owner="$2" mode="${3:-755}"
+    mkdir -p "$dir"
+    chown "$owner" "$dir"
+    chmod "$mode" "$dir"
+}
+
+# --- UID/GID remapping for bind mount compatibility ---
+PUID=${PUID:-33}
+PGID=${PGID:-33}
+
+if [ "$PGID" != "33" ]; then
+    echo "Remapping www-data group to GID $PGID..."
+    # Avoid conflict if GID is already in use by another group
+    EXISTING_GROUP=$(getent group "$PGID" 2>/dev/null | cut -d: -f1)
+    if [ -n "$EXISTING_GROUP" ] && [ "$EXISTING_GROUP" != "www-data" ]; then
+        groupmod -g 9999 "$EXISTING_GROUP"
+    fi
+    groupmod -g "$PGID" www-data
+fi
+
+if [ "$PUID" != "33" ]; then
+    echo "Remapping www-data user to UID $PUID..."
+    EXISTING_USER=$(getent passwd "$PUID" 2>/dev/null | cut -d: -f1)
+    if [ -n "$EXISTING_USER" ] && [ "$EXISTING_USER" != "www-data" ]; then
+        usermod -u 9999 "$EXISTING_USER"
+    fi
+    usermod -u "$PUID" www-data
+fi
+
+# Update ownership on static app files (only needed when remapped)
+if [ "$PUID" != "33" ] || [ "$PGID" != "33" ]; then
+    echo "Updating file ownership for UID=$PUID GID=$PGID..."
+    chown -R www-data:www-data /var/www/bbs
+fi
+
+# --- Storage directories (unified) ---
+# All persistent directories are created and permissioned in one place.
+# This ensures correct ownership AND write permissions on filesystems
+# like btrfs (Synology) that may create directories without write bits.
+ensure_dir /var/bbs                 www-data:www-data   755
+ensure_dir /var/bbs/home            www-data:www-data   755
+ensure_dir /var/bbs/cache           www-data:www-data   755
+ensure_dir /var/bbs/backups         www-data:www-data   750
+ensure_dir /var/bbs/tmp             www-data:www-data   1777
+ensure_dir /var/bbs/config          www-data:www-data   755
+ensure_dir /var/bbs/clickhouse      clickhouse:clickhouse 755
+ensure_dir /var/bbs/mysql           mysql:mysql         755
+ensure_dir /run/mysqld              mysql:mysql         755
+ensure_dir /run/sshd                root:root           755
+ensure_dir /var/log/clickhouse-server clickhouse:clickhouse 755
+
+export TMPDIR=/var/bbs/tmp
+
 # --- SSH host key persistence ---
 # Persist host keys on the data volume so agents don't see "host key changed"
 # errors after a container rebuild
@@ -22,23 +77,13 @@ fi
 # NOTE: sshd is started AFTER SSH users are recreated (see below)
 
 # --- MariaDB ---
-# Store database files on the persistent volume
 MYSQL_DATADIR="/var/bbs/mysql"
-mkdir -p "$MYSQL_DATADIR"
-chown mysql:mysql "$MYSQL_DATADIR"
 
 echo "Starting MariaDB..."
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
     echo "Initializing MariaDB data directory..."
-    mysql_install_db --user=mysql --datadir="$MYSQL_DATADIR" > /dev/null 2>&1
+    mysql_install_db --user=mysql --datadir="$MYSQL_DATADIR" --skip-test-db > /dev/null 2>&1
 fi
-
-# Use persistent volume for temp files so large catalog imports and MySQL
-# temp tables don't fill the container's overlay filesystem
-mkdir -p /var/bbs/tmp
-chown www-data:www-data /var/bbs/tmp
-chmod 1777 /var/bbs/tmp
-export TMPDIR=/var/bbs/tmp
 
 # Force MariaDB to use UTC so CURRENT_TIMESTAMP values are consistent
 # with what TimeHelper::format() expects, regardless of the Docker host timezone.
@@ -49,7 +94,7 @@ default-time-zone = '+00:00'
 tmpdir = /var/bbs/tmp
 MYCNF
 
-mysqld_safe --datadir="$MYSQL_DATADIR" &
+mariadbd-safe --datadir="$MYSQL_DATADIR" &
 sleep 3
 
 # Wait for MySQL to be ready
@@ -64,9 +109,7 @@ done
 # Start ClickHouse (catalog engine)
 echo "Starting ClickHouse..."
 if command -v clickhouse-server &>/dev/null; then
-    # Store ClickHouse data on persistent volume (same pattern as MariaDB)
-    mkdir -p /var/bbs/clickhouse /var/log/clickhouse-server /etc/clickhouse-server/config.d
-    chown -R clickhouse:clickhouse /var/bbs/clickhouse /var/log/clickhouse-server
+    mkdir -p /etc/clickhouse-server/config.d
     # Install config override to disable system log tables (reduces idle disk I/O)
     if [ -f "/var/www/bbs/config/clickhouse-server-override.xml" ]; then
         cp /var/www/bbs/config/clickhouse-server-override.xml /etc/clickhouse-server/config.d/bbs-override.xml
@@ -109,7 +152,7 @@ SERVER_HOST="$(echo "${APP_URL:-http://localhost}" | sed -E 's|https?://||' | se
 # all encrypted data becomes unrecoverable.
 ENV_VOLUME="/var/bbs/config/.env"
 ENV_APP="/var/www/bbs/config/.env"
-mkdir -p /var/bbs/config /var/www/bbs/config
+mkdir -p /var/www/bbs/config
 
 # Migration: move existing .env from container filesystem to volume
 if [ -f "$ENV_APP" ] && [ ! -L "$ENV_APP" ] && [ ! -f "$ENV_VOLUME" ]; then
@@ -173,18 +216,8 @@ if ! mysql -e "SELECT 1 FROM mysql.user WHERE user='bbs'" 2>/dev/null | grep -q 
     mysql -e "FLUSH PRIVILEGES;"
 fi
 
-# --- Storage directories ---
-mkdir -p /var/bbs/home
-mkdir -p /var/bbs/cache
-mkdir -p /var/bbs/backups
-
-# Set permissions on persistent volume directories
-# Only chown the top-level dirs (not -R) — per-user subdirs under home/ and cache/
-# have their own ownership (user:www-data) set by bbs-ssh-helper. A recursive chown
-# would clobber .ssh/authorized_keys and per-user borg cache directories.
-chown www-data:www-data /var/bbs/home /var/bbs/cache
+# Set permissions on backups (recursive for nested content)
 chown -R www-data:www-data /var/bbs/backups
-chown -R mysql:mysql "$MYSQL_DATADIR"
 
 # Create ClickHouse database and tables
 if curl -sf http://localhost:8123/ping >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Related to Discussion: #121

Docker bind mounts cause permission issues when the container's www-data user (UID 33) doesn't match the host user. This is a common problem across all platforms when using bind mounts instead of Docker volumes.

Additionally, some filesystems (notably btrfs on Synology NAS) create directories without write permission bits even when ownership is correct, causing service startup failures.

This PR adds PUID/PGID environment variable support to remap the container's www-data user to match the host user, and introduces an `ensure_dir()` helper that always sets ownership and permissions together to ensure correct behavior across all filesystems.

## Changes
- Add PUID/PGID environment variables to Dockerfile (default: 33/33)
- Add UID/GID remapping logic in entrypoint.sh with collision detection for existing system users/groups
- Add `ensure_dir()` helper function that sets mkdir + chown + chmod atomically
- Consolidate all directory creation into a single block that runs before any service starts
- Replace deprecated `mysqld_safe` with `mariadbd-safe`
- Add `--skip-test-db` to `mysql_install_db`
- Add `--no-install-recommends` to apt-get calls to reduce image size (~70MB)
- Consolidate RUN layers and clean up build caches (pip, composer, apt)
- Add PUID/PGID to docker-compose.yml (commented out) and .env.example with usage instructions
- Add docker-compose.yml, .env, docs/, and other non-build files to .dockerignore

## Testing
- [x] Tested on Docker
- [ ] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows

Tested on Synology NAS (DS series, btrfs) with Docker bind mount and PUID=1026/PGID=100. Verified clean startup of all services (MariaDB, ClickHouse, Apache, SSH), successful client creation, and correct file ownership on the host volume.