### PR TITLE
Add CachyOS to agent installer

### DIFF
--- a/agent/install.sh
+++ b/agent/install.sh
@@ -188,7 +188,7 @@ install_borg() {
         fedora)
             dnf install -y borgbackup python3 >/dev/null 2>&1
             ;;
-        arch|manjaro|endeavouros)
+        arch|manjaro|endeavouros|cachyos)
             pacman -Sy --noconfirm borg python >/dev/null 2>&1
             ;;
         opensuse*|sles)


### PR DESCRIPTION
## Summary

Added [CachyOS](https://cachyos.org/) to the list of Arch-based systems for automatic dependency installation.

## Changes

- Add `CachyOS` to the agent installer script

## Testing

- [ ] Tested on Docker
- [x] Tested on bare metal
- [x] Agent changes tested on Linux
- [ ] Agent changes tested on Windows
