### PR TITLE
Format backup duration in human-readable form

### DIFF
--- a/src/Controllers/Api/AgentApiController.php
+++ b/src/Controllers/Api/AgentApiController.php
@@ -468,7 +468,7 @@ class AgentApiController extends Controller
         // Log the result
         $level = $result === 'completed' ? 'info' : 'error';
         $message = $result === 'completed'
-            ? "{$taskLabel} completed: job #{$jobId}" . (($data['files_total'] ?? 0) > 0 ? ", {$data['files_total']} files" : '') . ", {$duration}s"
+            ? "{$taskLabel} completed: job #{$jobId}" . (($data['files_total'] ?? 0) > 0 ? ", {$data['files_total']} files" : '') . ", " . $this->formatDuration($duration)
             : "{$taskLabel} failed: job #{$jobId} — " . ($input['error_log'] ?? 'unknown error');
 
         $this->db->insert('server_log', [
@@ -514,7 +514,7 @@ class AgentApiController extends Controller
                         $agent['id'],
                         (int)$job['backup_plan_id'],
                         "Backup completed for plan \"{$planName}\" on client \"{$agent['name']}\"" .
-                            (($data['files_total'] ?? 0) > 0 ? " — {$data['files_total']} files in {$duration}s" : ''),
+                            (($data['files_total'] ?? 0) > 0 ? " — {$data['files_total']} files in " . $this->formatDuration($duration) : ''),
                         'info'
                     );
                 }
@@ -1104,6 +1104,23 @@ class AgentApiController extends Controller
         $raw = file_get_contents('php://input');
         $data = json_decode($raw, true);
         return is_array($data) ? $data : [];
+    }
+
+    private function formatDuration(int $seconds): string
+    {
+        $d = intdiv($seconds, 86400);
+        $h = intdiv($seconds % 86400, 3600);
+        $m = intdiv($seconds % 3600, 60);
+        $s = $seconds % 60;
+
+        $parts = [];
+
+        if ($d > 0) $parts[] = "{$d}d";
+        if ($h > 0) $parts[] = "{$h}h";
+        if ($m > 0) $parts[] = "{$m}m";
+        if ($s > 0 || empty($parts)) $parts[] = "{$s}s";
+
+        return implode(' ', $parts);
     }
 
     private function formatBytesLog(int $bytes): string


### PR DESCRIPTION
Replace raw duration in seconds with a compact human-readable format (e.g. 27m 0s, 1h 12m) in backup completion  messages.

Improves readability of notifications and logs for long-running jobs.

This change is self-contained and does not affect existing logic.

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [ ] Tested on Docker
- [x] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows
