### PR TITLE
Add Dropbear SSH key conversion support and fix header alignment

### DIFF
--- a/agent/install.sh
+++ b/agent/install.sh
@@ -436,6 +436,7 @@ install_ssh_key() {
                 fi
             else
                 print_warning "dropbearconvert not found; leaving key in OpenSSH format"
+                print_info "Install dropbearconvert and re-run installer to convert key if using Dropbear SSH"
             fi
         fi
 

--- a/agent/install.sh
+++ b/agent/install.sh
@@ -63,7 +63,7 @@ stop_spinner() {
 print_header() {
     echo ""
     echo -e "${BOLD}${BLUE}╔══════════════════════════════════════════════════════════════╗${NC}"
-    echo -e "${BOLD}${BLUE}║${NC}          ${BOLD}Borg Backup Server — Agent Installer${NC}                ${BOLD}${BLUE}║${NC}"
+    echo -e "${BOLD}${BLUE}║${NC}             ${BOLD}Borg Backup Server — Agent Installer${NC}             ${BOLD}${BLUE}║${NC}"
     echo -e "${BOLD}${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 }
@@ -424,6 +424,12 @@ install_ssh_key() {
 
     if [ -n "$ssh_key" ] && [ "$ssh_key" != "" ]; then
         echo "$ssh_key" > "$CONFIG_DIR/ssh_key"
+        # Check if ssh is Dropbear (common on embedded devices) and convert if needed
+        if ssh -V 2>&1 | grep -q "Dropbear"; then
+            print_info "Converting SSH key to Dropbear format"
+            dropbearconvert openssh dropbear "$CONFIG_DIR/ssh_key" "$CONFIG_DIR/ssh_key.dropbear"
+            mv -f "$CONFIG_DIR/ssh_key.dropbear" "$CONFIG_DIR/ssh_key"
+        fi
         chmod 600 "$CONFIG_DIR/ssh_key"
         print_success "SSH key installed to ${DIM}$CONFIG_DIR/ssh_key${NC}"
         SSH_STATUS="installed"
@@ -717,7 +723,7 @@ print_summary() {
 
     echo ""
     echo -e "${BOLD}${GREEN}╔══════════════════════════════════════════════════════════════╗${NC}"
-    echo -e "${BOLD}${GREEN}║${NC}                  ${BOLD}${GREEN}Installation Complete!${NC}                     ${BOLD}${GREEN}║${NC}"
+    echo -e "${BOLD}${GREEN}║${NC}                    ${BOLD}${GREEN}Installation Complete!${NC}                    ${BOLD}${GREEN}║${NC}"
     echo -e "${BOLD}${GREEN}╚══════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 

--- a/agent/install.sh
+++ b/agent/install.sh
@@ -424,12 +424,21 @@ install_ssh_key() {
 
     if [ -n "$ssh_key" ] && [ "$ssh_key" != "" ]; then
         echo "$ssh_key" > "$CONFIG_DIR/ssh_key"
-        # Check if ssh is Dropbear (common on embedded devices) and convert if needed
+        # Check if we have Dropbear ssh (common on embedded devices) and convert if needed
         if ssh -V 2>&1 | grep -q "Dropbear"; then
-            print_info "Converting SSH key to Dropbear format"
-            dropbearconvert openssh dropbear "$CONFIG_DIR/ssh_key" "$CONFIG_DIR/ssh_key.dropbear"
-            mv -f "$CONFIG_DIR/ssh_key.dropbear" "$CONFIG_DIR/ssh_key"
+            if command -v dropbearconvert >/dev/null 2>&1; then 
+                print_info "Converting SSH key to Dropbear format"
+                if dropbearconvert openssh dropbear "$CONFIG_DIR/ssh_key" "$CONFIG_DIR/ssh_key.dropbear" 2>/dev/null; then
+                    mv -f "$CONFIG_DIR/ssh_key.dropbear" "$CONFIG_DIR/ssh_key"
+                else
+                    print_warning "dropbearconvert failed; leaving key in OpenSSH format"
+                    rm -f "$CONFIG_DIR/ssh_key.dropbear"
+                fi
+            else
+                print_warning "dropbearconvert not found; leaving key in OpenSSH format"
+            fi
         fi
+
         chmod 600 "$CONFIG_DIR/ssh_key"
         print_success "SSH key installed to ${DIM}$CONFIG_DIR/ssh_key${NC}"
         SSH_STATUS="installed"


### PR DESCRIPTION
## Summary

Automatic SSH key format conversion for Dropbear SSH is now supported, enhancing compatibility with embedded devices. The installer also improves UI consistency by correcting header alignment.

## Changes

- Added support for converting OpenSSH keys to Dropbear format during installation.
- Fixed visual alignment of header and summary text boxes in the installer output.

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [ ] Tested on Docker
- [X] Tested on bare metal (Server and Client)
- [X] Agent changes tested on **OpenATV Enigma2** Linux
- [ ] Agent changes tested on Windows

