### PR TITLE
Add current time indicators to schedules view minus one bug in Desktop WEB UI

### DIFF
--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -336,7 +336,34 @@ class DashboardController extends Controller
         if ($agentWhere !== '1=1') {
             $errorCountQuery .= " AND ({$agentWhere} OR sl.agent_id IS NULL)";
         }
-        $errorCount = $this->db->fetchOne($errorCountQuery, $jobParams)['cnt'];
+        $logErrorCount = (int) $this->db->fetchOne($errorCountQuery, $jobParams)['cnt'];
+
+        $failedJobCount = (int) $this->db->fetchOne(
+            "SELECT COUNT(*) as cnt
+             FROM backup_jobs bj
+             JOIN agents a ON a.id = bj.agent_id
+             WHERE bj.status = 'failed'
+               AND bj.completed_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
+               {$jobScope}",
+            $jobParams
+        )['cnt'];
+
+        // Operational alerts such as an offline client missing a schedule do not
+        // always create a failed backup_job row, but they are still dashboard
+        // errors the user needs to notice.
+        $alertScope = $agentWhere === '1=1' ? '' : "AND ({$agentWhere} OR n.agent_id IS NULL)";
+        $operationalAlertCount = (int) $this->db->fetchOne(
+            "SELECT COUNT(*) as cnt
+             FROM notifications n
+             LEFT JOIN agents a ON a.id = n.agent_id
+             WHERE n.type IN ('agent_offline', 'missed_schedule')
+               AND n.resolved_at IS NULL
+               AND n.last_occurred_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
+               {$alertScope}",
+            $jobParams
+        )['cnt'];
+
+        $errorCount = $logErrorCount + $failedJobCount + $operationalAlertCount;
 
         // Optional task-type filter for the Recently Completed list. Accepts
         // a comma-separated list of category keys (backup, restore, prune,
@@ -411,6 +438,31 @@ class DashboardController extends Controller
             ORDER BY hour
         ", $jobParams);
 
+        $failedJobsChart = $this->db->fetchAll("
+            SELECT DATE_FORMAT(bj.completed_at, '%Y-%m-%d %H:00') as hour,
+                   COUNT(*) as count
+            FROM backup_jobs bj
+            JOIN agents a ON a.id = bj.agent_id
+            WHERE bj.status = 'failed'
+              AND bj.completed_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
+              {$jobScope}
+            GROUP BY hour
+            ORDER BY hour
+        ", $jobParams);
+
+        $alertChart = $this->db->fetchAll("
+            SELECT DATE_FORMAT(n.last_occurred_at, '%Y-%m-%d %H:00') as hour,
+                   COUNT(*) as count
+            FROM notifications n
+            LEFT JOIN agents a ON a.id = n.agent_id
+            WHERE n.type IN ('agent_offline', 'missed_schedule')
+              AND n.resolved_at IS NULL
+              AND n.last_occurred_at > DATE_SUB(NOW(), INTERVAL 24 HOUR)
+              {$alertScope}
+            GROUP BY hour
+            ORDER BY hour
+        ", $jobParams);
+
         // Group task types into 3 categories
         $categoryMap = [
             'backup' => 'backups',
@@ -423,6 +475,12 @@ class DashboardController extends Controller
             $cat = $categoryMap[$row['task_type']] ?? null;
             if ($cat === null) continue;
             $hourCounts[$row['hour']][$cat] = ($hourCounts[$row['hour']][$cat] ?? 0) + (int) $row['count'];
+        }
+        foreach ($failedJobsChart as $row) {
+            $hourCounts[$row['hour']]['errors'] = ($hourCounts[$row['hour']]['errors'] ?? 0) + (int) $row['count'];
+        }
+        foreach ($alertChart as $row) {
+            $hourCounts[$row['hour']]['errors'] = ($hourCounts[$row['hour']]['errors'] ?? 0) + (int) $row['count'];
         }
 
         // Fill in missing hours
@@ -443,6 +501,7 @@ class DashboardController extends Controller
                 'backups' => $counts['backups'] ?? 0,
                 'restores' => $counts['restores'] ?? 0,
                 's3_sync' => $counts['s3_sync'] ?? 0,
+                'errors' => $counts['errors'] ?? 0,
             ];
         }
 

--- a/src/Views/dashboard/index.php
+++ b/src/Views/dashboard/index.php
@@ -715,6 +715,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 { label: 'Backups', data: chartData.map(d => d.backups), backgroundColor: 'rgba(54, 162, 235, 0.7)', borderRadius: 2 },
                 { label: 'Restores', data: chartData.map(d => d.restores), backgroundColor: 'rgba(255, 159, 64, 0.7)', borderRadius: 2 },
                 { label: 'S3 Sync', data: chartData.map(d => d.s3_sync), backgroundColor: 'rgba(75, 192, 192, 0.7)', borderRadius: 2 },
+                { label: 'Errors', data: chartData.map(d => d.errors), backgroundColor: 'rgba(220, 53, 69, 0.8)', borderRadius: 2 },
             ]
         },
         options: {

--- a/src/Views/dashboard/index.php
+++ b/src/Views/dashboard/index.php
@@ -19,6 +19,16 @@ $fmtUptime = function (?int $s): string {
     if ($h > 0) return "{$h}h {$m}m";
     return "{$m}m";
 };
+$fmtDuration = function (?int $s): string {
+    if (!$s || $s <= 0) return '--';
+    $h = intdiv($s, 3600);
+    $s %= 3600;
+    $m = intdiv($s, 60);
+    $s %= 60;
+    if ($h > 0) return sprintf('%dh %02dm', $h, $m);
+    if ($m > 0) return sprintf('%dm %02ds', $m, $s);
+    return "{$s}s";
+};
 
 // Dedup savings % (original data vs actual disk footprint).
 // Clamp the displayed value at 99.9% when there's still bytes on disk —
@@ -517,7 +527,7 @@ $dfFix = function (string $s): string {
                             <td class="d-table-cell-md"><?= htmlspecialchars($j['plan_name'] ?? '--') ?></td>
                             <td class="d-table-cell-md"><?= htmlspecialchars($j['repo_name'] ?? '--') ?></td>
                             <td><?= TimeHelper::ago($j['completed_at']) ?></td>
-                            <td class="d-table-cell-md"><?= $j['duration_seconds'] ? gmdate('i\m s\s', (int) $j['duration_seconds']) : '--' ?></td>
+                            <td class="d-table-cell-md"><?= $fmtDuration((int) ($j['duration_seconds'] ?? 0)) ?></td>
                             <td class="text-center"><i class="bi <?= $statusIcon ?>"></i></td>
                         </tr>
                     <?php endforeach; ?>
@@ -870,8 +880,8 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         function fmtDur(s) {
             s = parseInt(s) || 0;
-            if (s >= 3600) return Math.floor(s/3600) + 'h ' + Math.floor((s%3600)/60) + 'm';
-            if (s >= 60) return Math.floor(s/60) + 'm ' + (s%60) + 's';
+            if (s >= 3600) return Math.floor(s/3600) + 'h ' + String(Math.floor((s%3600)/60)).padStart(2, '0') + 'm';
+            if (s >= 60) return Math.floor(s/60) + 'm ' + String(s%60).padStart(2, '0') + 's';
             return s > 0 ? s + 's' : '--';
         }
 

--- a/src/Views/schedules/week.php
+++ b/src/Views/schedules/week.php
@@ -46,7 +46,10 @@ foreach ($blocksByDay as &$dayBlocks) {
 }
 unset($dayBlocks);
 
-$todayIdx = ((int) (new \DateTime('now', new \DateTimeZone($userTz)))->format('N')) - 1;
+$nowInUserTz = new \DateTime('now', new \DateTimeZone($userTz));
+$todayIdx = ((int) $nowInUserTz->format('N')) - 1;
+$currentMinuteOfDay = ((int) $nowInUserTz->format('G')) * 60 + (int) $nowInUserTz->format('i');
+$currentTimeLabel = $is24h ? $nowInUserTz->format('H:i') : $nowInUserTz->format('g:i A');
 
 function bbs_agent_color(int $id): string
 {
@@ -102,6 +105,44 @@ function bbs_histogram_ticks(int $max): array
     width: 1px;
     background: var(--bs-border-color);
     opacity: 0.15;
+}
+.hist-current-time-line {
+    position: absolute;
+    top: 0;
+    bottom: 18px;
+    width: 0;
+    border-left: 2px solid var(--bs-danger);
+    z-index: 3;
+    pointer-events: none;
+}
+.hist-current-time-line::before {
+    content: "";
+    position: absolute;
+    left: -5px;
+    top: -5px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--bs-danger);
+}
+.hist-current-time-line .current-time-label {
+    position: absolute;
+    top: 2px;
+    left: 8px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: var(--bs-danger);
+    color: #fff;
+    font-size: 0.68rem;
+    line-height: 1.25;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+}
+.hist-current-time-line.near-end .current-time-label {
+    left: auto;
+    right: 8px;
 }
 .hist-bar-wrap {
     position: relative;
@@ -250,6 +291,39 @@ function bbs_histogram_ticks(int $max): array
     opacity: 0.35;
 }
 .day-col .hour-line.major { opacity: 0.6; }
+.current-time-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 0;
+    border-top: 2px solid var(--bs-danger);
+    z-index: 20;
+    pointer-events: none;
+}
+.current-time-line::before {
+    content: "";
+    position: absolute;
+    left: -5px;
+    top: -5px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--bs-danger);
+}
+.current-time-line .current-time-label {
+    position: absolute;
+    right: 8px;
+    top: -11px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: var(--bs-danger);
+    color: #fff;
+    font-size: 0.68rem;
+    line-height: 1.25;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+}
 .day-block {
     position: absolute;
     padding: 1px 8px;
@@ -470,6 +544,14 @@ function bbs_histogram_ticks(int $max): array
                         <div class="vline" style="left: <?= $leftPct ?>%;"></div>
                     <?php endfor; ?>
                 </div>
+                <?php if ($dIdx === $todayIdx): ?>
+                    <?php $nowLeftPct = ($currentMinuteOfDay / 1440) * 100; ?>
+                    <div class="hist-current-time-line <?= $nowLeftPct > 80 ? 'near-end' : '' ?>"
+                         style="left: calc(56px + ((100% - 56px) * <?= $nowLeftPct / 100 ?>));"
+                         title="Current time in <?= htmlspecialchars($userTz) ?>">
+                        <span class="current-time-label">Now time: <?= htmlspecialchars($currentTimeLabel) ?></span>
+                    </div>
+                <?php endif; ?>
 
                 <div class="hist-yaxis">
                     <?php foreach ($yTicks as $tick): ?>
@@ -562,6 +644,13 @@ function bbs_histogram_ticks(int $max): array
 
                     <?php for ($dIdx = 0; $dIdx < 7; $dIdx++): ?>
                     <div class="day-content" data-day-idx="<?= $dIdx ?>" style="<?= $dIdx === $todayIdx ? '' : 'display: none;' ?>">
+                        <?php if ($dIdx === $todayIdx): ?>
+                        <div class="current-time-line"
+                             style="top: <?= $currentMinuteOfDay * ($pxPerHour / 60) ?>px;"
+                             title="Current time in <?= htmlspecialchars($userTz) ?>">
+                            <span class="current-time-label">Now time: <?= htmlspecialchars($currentTimeLabel) ?></span>
+                        </div>
+                        <?php endif; ?>
                         <?php foreach ($blocksByDay[$dIdx] as $b): ?>
                             <?php
                             $top = $b['start_min'] * ($pxPerHour / 60);


### PR DESCRIPTION

<!-- Brief description of what this PR does and why -->

## Summary
- Add a user-timezone-aware current time marker to the schedules day view
- Add a vertical current time marker to the Load By Hour chart for Today
- Label both markers with the current time using the user's configured time format
- Fix bug with "Recently complete - Duration" in index 

## Testing
- `php -l src/Views/schedules/week.php`

<!-- How was this tested? Docker, bare metal, or both? -->

- [+] Tested on Docker
- [+] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows
