### PR TITLE
Add Telegram notification thread support

### DIFF
--- a/src/Views/notification-services/index.php
+++ b/src/Views/notification-services/index.php
@@ -75,7 +75,7 @@ $eventColors = [
                     <div class="row">
                         <div class="col-md-6">
                             <strong>Discord:</strong> discord://webhook_id/webhook_token<br>
-                            <strong>Telegram:</strong> tgram://bot_token/chat_id<br>
+                            <strong>Telegram:</strong> tgram://bot_token/chat_id[:thread]<br>
                             <strong>Slack:</strong> slack://tokenA/tokenB/tokenC<br>
                             <strong>Pushover:</strong> pover://user@token
                         </div>
@@ -578,11 +578,15 @@ const serviceSchemas = {
         label: 'Telegram',
         fields: [
             { name: 'bot_token', label: 'Bot Token', type: 'text', required: true, placeholder: '123456789:ABCdefGHI...', width: 'col-md-6' },
-            { name: 'chat_id', label: 'Chat ID', type: 'text', required: true, placeholder: '-1001234567890', width: 'col-md-6' }
+            { name: 'chat_id', label: 'Chat ID', type: 'text', required: true, placeholder: '-1001234567890', width: 'col-md-4' },
+            { name: 'thread', label: 'Thread (optional)', type: 'text', placeholder: '1234567', width: 'col-md-2' }
         ],
-        help: 'Create a bot via @BotFather, then get chat ID by messaging @userinfobot or from group info',
+        help: 'Create a bot via @BotFather, then get chat ID by messaging @userinfobot or from group info. Use Thread for a Telegram topic ID.',
         build: function(f) {
-            return `tgram://${f.bot_token || ''}/${f.chat_id || ''}`;
+            const chatId = f.chat_id || '';
+            const thread = (f.thread || '').trim();
+            const target = thread ? `${chatId}:${encodeURIComponent(thread)}` : chatId;
+            return `tgram://${f.bot_token || ''}/${target}`;
         }
     },
     pover: {

--- a/src/Views/settings/index.php
+++ b/src/Views/settings/index.php
@@ -467,7 +467,7 @@ unset($ns);
                     <div class="row">
                         <div class="col-md-6">
                             <strong>Discord:</strong> discord://webhook_id/webhook_token<br>
-                            <strong>Telegram:</strong> tgram://bot_token/chat_id<br>
+                            <strong>Telegram:</strong> tgram://bot_token/chat_id[:thread]<br>
                             <strong>Slack:</strong> slack://tokenA/tokenB/tokenC<br>
                             <strong>Pushover:</strong> pover://user@token
                         </div>
@@ -977,11 +977,15 @@ const serviceSchemas = {
         label: 'Telegram',
         fields: [
             { name: 'bot_token', label: 'Bot Token', type: 'text', required: true, placeholder: '123456789:ABCdefGHI...', width: 'col-md-6' },
-            { name: 'chat_id', label: 'Chat ID', type: 'text', required: true, placeholder: '-1001234567890', width: 'col-md-6' }
+            { name: 'chat_id', label: 'Chat ID', type: 'text', required: true, placeholder: '-1001234567890', width: 'col-md-4' },
+            { name: 'thread', label: 'Thread (optional)', type: 'text', placeholder: '1234567', width: 'col-md-2' }
         ],
-        help: 'Create a bot via @BotFather, then get chat ID by messaging @userinfobot or from group info',
+        help: 'Create a bot via @BotFather, then get chat ID by messaging @userinfobot or from group info. Use Thread for a Telegram topic ID.',
         build: function(f) {
-            return `tgram://${f.bot_token || ''}/${f.chat_id || ''}`;
+            const chatId = f.chat_id || '';
+            const thread = (f.thread || '').trim();
+            const target = thread ? `${chatId}:${encodeURIComponent(thread)}` : chatId;
+            return `tgram://${f.bot_token || ''}/${target}`;
         }
     },
     pover: {


### PR DESCRIPTION
## Summary

Adds Telegram thread/topic support to Apprise notification service setup in the Web UI.

When adding a Telegram notification service, users can now optionally provide a Thread value. If set, the generated Apprise URL targets that Telegram topic using:

`tgram://bot_token/chat_id:thread`

If the field is left empty, the existing behavior remains unchanged:

`tgram://bot_token/chat_id`

## How to Find the Telegram Thread ID

If your bot is added to a Telegram group where topics are enabled:

1. Create or open the target topic.
2. Send any message in that topic.
3. Copy the message link.
4. Inspect the URL, which looks like:

`t.me/c/yourbot-id/thread-number/some-number`

Use the `thread-number` value in the new Thread field.

## Testing

- Verified Telegram notifications with a thread/topic target.
- Ran PHP syntax checks for the updated view files.

## Changes

- src/Views/notification-services/index.php
- src/Views/settings/index.php

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows


Desktop:

<img width="2406" height="569" alt="image" src="https://github.com/user-attachments/assets/b8b2d35e-890e-455b-b8c9-abadfd790b2e" />

<br>
Mobile:

<img width="295" height="640" alt="image" src="https://github.com/user-attachments/assets/1d04f6ff-19b6-4166-896c-d231d91d937f" />


