### PR TITLE
Add generated favicon branding assets as a one-window service

### DIFF
--- a/migrations/081_settings_value_mediumtext.sql
+++ b/migrations/081_settings_value_mediumtext.sql
@@ -1,0 +1,2 @@
+-- Allow generated branding assets, including 512x512 favicon PNGs, to fit safely.
+ALTER TABLE settings MODIFY `value` MEDIUMTEXT DEFAULT NULL;

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,12 +7,12 @@
     "theme_color": "#2c3e50",
     "icons": [
         {
-            "src": "/images/icon-192.png",
+            "src": "/branding/favicon/192",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/images/icon-512.png",
+            "src": "/branding/favicon/512",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/schema.sql
+++ b/schema.sql
@@ -281,7 +281,7 @@ CREATE TABLE server_log (
 
 CREATE TABLE settings (
     `key` VARCHAR(100) PRIMARY KEY,
-    `value` TEXT DEFAULT NULL
+    `value` MEDIUMTEXT DEFAULT NULL
 );
 
 INSERT INTO settings (`key`, `value`) VALUES

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -239,15 +239,48 @@ class SettingsController extends Controller
 
         $saved = [];
 
+        $faviconSizes = [16, 32, 48, 96, 180, 192, 512];
+
+        if (!empty($_POST['branding_logo_data'])) {
+            $data = $_POST['branding_logo_data'];
+            if ($this->isBase64Png($data)) {
+                $this->saveSetting('branding_login_logo', $data);
+                $saved[] = 'Login logo updated';
+            }
+        }
+
+        if (!empty($_POST['branding_favicon_data'])) {
+            $faviconData = json_decode($_POST['branding_favicon_data'], true);
+            if (is_array($faviconData)) {
+                foreach ($faviconSizes as $size) {
+                    $key = (string) $size;
+                    if (!empty($faviconData[$key]) && is_string($faviconData[$key]) && $this->isBase64Png($faviconData[$key])) {
+                        $this->saveSetting('branding_favicon_' . $size, $faviconData[$key]);
+                    }
+                }
+                $saved[] = 'Favicons updated';
+            }
+        }
+
+        if (!empty($_POST['branding_favicon_ico_data'])) {
+            $icoData = $_POST['branding_favicon_ico_data'];
+            if ($this->isBase64Ico($icoData)) {
+                $this->saveSetting('branding_favicon_ico', $icoData);
+            }
+        }
+
         // Handle navbar icon
         if (!empty($_POST['remove_branding_icon'])) {
             $this->db->query("DELETE FROM settings WHERE `key` = 'branding_icon'");
+            foreach ($faviconSizes as $size) {
+                $this->db->query("DELETE FROM settings WHERE `key` = ?", ['branding_favicon_' . $size]);
+            }
+            $this->db->query("DELETE FROM settings WHERE `key` = 'branding_favicon_ico'");
             $saved[] = 'Navbar icon removed';
+            $saved[] = 'Favicons removed';
         } elseif (!empty($_POST['branding_icon_data'])) {
             $data = $_POST['branding_icon_data'];
-            // Validate it's valid base64 PNG
-            $decoded = base64_decode($data, true);
-            if ($decoded && substr($decoded, 0, 4) === "\x89PNG") {
+            if ($this->isBase64Png($data)) {
                 $this->saveSetting('branding_icon', $data);
                 $saved[] = 'Navbar icon updated';
             }
@@ -259,8 +292,7 @@ class SettingsController extends Controller
             $saved[] = 'Login logo removed';
         } elseif (!empty($_POST['branding_login_logo_data'])) {
             $data = $_POST['branding_login_logo_data'];
-            $decoded = base64_decode($data, true);
-            if ($decoded && substr($decoded, 0, 4) === "\x89PNG") {
+            if ($this->isBase64Png($data)) {
                 $this->saveSetting('branding_login_logo', $data);
                 $saved[] = 'Login logo updated';
             }
@@ -273,8 +305,93 @@ class SettingsController extends Controller
             $saved[] = 'Login theme updated';
         }
 
+        if (!empty($saved)) {
+            $this->saveSetting('branding_version', (string) time());
+        }
+
         $this->flash('success', !empty($saved) ? implode('. ', $saved) . '.' : 'Branding saved.');
         $this->redirect('/settings?tab=branding');
+    }
+
+    public function favicon(int $size): void
+    {
+        $allowed = [16, 32, 48, 96, 180, 192, 512];
+        if (!in_array($size, $allowed, true)) {
+            http_response_code(404);
+            echo 'Not Found';
+            return;
+        }
+
+        $row = $this->db->fetchOne("SELECT `value` FROM settings WHERE `key` = ?", ['branding_favicon_' . $size]);
+        $png = null;
+        if (!empty($row['value']) && $this->isBase64Png($row['value'])) {
+            $png = base64_decode($row['value']);
+        }
+
+        if ($png === null) {
+            $fallback = $this->defaultFaviconPath($size);
+            if (!$fallback || !is_file($fallback)) {
+                http_response_code(404);
+                echo 'Not Found';
+                return;
+            }
+            $png = file_get_contents($fallback);
+        }
+
+        header('Content-Type: image/png');
+        header('Cache-Control: public, max-age=3600');
+        echo $png;
+    }
+
+    public function faviconIco(): void
+    {
+        $row = $this->db->fetchOne("SELECT `value` FROM settings WHERE `key` = 'branding_favicon_ico'");
+        if (!empty($row['value']) && $this->isBase64Ico($row['value'])) {
+            header('Content-Type: image/x-icon');
+            header('Cache-Control: public, max-age=3600');
+            echo base64_decode($row['value']);
+            return;
+        }
+
+        $fallback = $this->defaultFaviconPath(32);
+        if (!$fallback || !is_file($fallback)) {
+            http_response_code(404);
+            echo 'Not Found';
+            return;
+        }
+
+        header('Content-Type: image/png');
+        header('Cache-Control: public, max-age=3600');
+        echo file_get_contents($fallback);
+    }
+
+    public function manifest(): void
+    {
+        $versionRow = $this->db->fetchOne("SELECT `value` FROM settings WHERE `key` = 'branding_version'");
+        $version = urlencode($versionRow['value'] ?? 'default');
+
+        header('Content-Type: application/manifest+json');
+        header('Cache-Control: public, max-age=3600');
+        echo json_encode([
+            'name' => 'Borg Backup Server',
+            'short_name' => 'BBS',
+            'start_url' => '/',
+            'display' => 'standalone',
+            'background_color' => '#1a1d21',
+            'theme_color' => '#2c3e50',
+            'icons' => [
+                [
+                    'src' => '/branding/favicon/192?v=' . $version,
+                    'sizes' => '192x192',
+                    'type' => 'image/png',
+                ],
+                [
+                    'src' => '/branding/favicon/512?v=' . $version,
+                    'sizes' => '512x512',
+                    'type' => 'image/png',
+                ],
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
     public function createApiToken(): void
@@ -327,6 +444,36 @@ class SettingsController extends Controller
         } else {
             $this->db->insert('settings', ['key' => $key, 'value' => $value]);
         }
+    }
+
+    private function isBase64Png(string $data): bool
+    {
+        $decoded = base64_decode($data, true);
+        return $decoded !== false && substr($decoded, 0, 8) === "\x89PNG\r\n\x1a\n";
+    }
+
+    private function isBase64Ico(string $data): bool
+    {
+        $decoded = base64_decode($data, true);
+        if ($decoded === false || strlen($decoded) < 6) {
+            return false;
+        }
+
+        $header = unpack('vreserved/vtype/vcount', substr($decoded, 0, 6));
+        return ($header['reserved'] ?? null) === 0
+            && ($header['type'] ?? null) === 1
+            && ($header['count'] ?? 0) > 0;
+    }
+
+    private function defaultFaviconPath(int $size): ?string
+    {
+        $publicDir = dirname(__DIR__, 2) . '/public';
+        return match ($size) {
+            180 => $publicDir . '/images/apple-touch-icon.png',
+            192 => $publicDir . '/images/icon-192.png',
+            512 => $publicDir . '/images/icon-512.png',
+            default => $publicDir . '/images/borg_icon_dark.png',
+        };
     }
 
     public function agentUpdatesJson(): void

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -46,7 +46,8 @@ class App
         // Redirect all UI routes to /upgrade while an upgrade is in progress
         $path = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?? '/';
         if (!str_starts_with($path, '/upgrade') && !str_starts_with($path, '/api/')
-            && !str_starts_with($path, '/login') && !str_starts_with($path, '/logout')) {
+            && !str_starts_with($path, '/login') && !str_starts_with($path, '/logout')
+            && !str_starts_with($path, '/branding/') && $path !== '/favicon.ico') {
             try {
                 $db = Database::getInstance();
                 $row = $db->fetchOne("SELECT `value` FROM settings WHERE `key` = 'upgrade_in_progress'");
@@ -176,6 +177,10 @@ class App
         $this->router->map('POST', '/settings/docker-setup', 'SettingsController@dockerSetup');
         $this->router->map('POST', '/settings/test-smtp', 'SettingsController@testSmtp');
         $this->router->map('POST', '/settings/check-update', 'SettingsController@checkUpdate');
+        $this->router->map('GET', '/branding/favicon/[i:size]', 'SettingsController@favicon');
+        $this->router->map('GET', '/branding/favicon.ico', 'SettingsController@faviconIco');
+        $this->router->map('GET', '/branding/manifest', 'SettingsController@manifest');
+        $this->router->map('GET', '/favicon.ico', 'SettingsController@faviconIco');
 
         // Storage Locations
         $this->router->map('GET', '/storage-locations', 'StorageLocationController@index');

--- a/src/Views/layouts/app.php
+++ b/src/Views/layouts/app.php
@@ -8,8 +8,17 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/style.css?v=<?= filemtime(__DIR__ . '/../../../public/css/style.css') ?>" rel="stylesheet">
-    <link rel="manifest" href="/manifest.json">
-    <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
+    <?php
+        $brandingVersionRow = \BBS\Core\Database::getInstance()->fetchOne("SELECT `value` FROM settings WHERE `key` = 'branding_version'");
+        $brandingVersion = urlencode($brandingVersionRow['value'] ?? 'default');
+    ?>
+    <link rel="icon" href="/branding/favicon.ico?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="16x16" href="/branding/favicon/16?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="32x32" href="/branding/favicon/32?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="48x48" href="/branding/favicon/48?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="96x96" href="/branding/favicon/96?v=<?= $brandingVersion ?>">
+    <link rel="apple-touch-icon" sizes="180x180" href="/branding/favicon/180?v=<?= $brandingVersion ?>">
+    <link rel="manifest" href="/branding/manifest?v=<?= $brandingVersion ?>">
     <meta name="theme-color" content="#2c3e50">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">

--- a/src/Views/layouts/auth.php
+++ b/src/Views/layouts/auth.php
@@ -11,6 +11,17 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">
+    <?php
+        $brandingVersionRow = \BBS\Core\Database::getInstance()->fetchOne("SELECT `value` FROM settings WHERE `key` = 'branding_version'");
+        $brandingVersion = urlencode($brandingVersionRow['value'] ?? 'default');
+    ?>
+    <link rel="icon" href="/branding/favicon.ico?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="16x16" href="/branding/favicon/16?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="32x32" href="/branding/favicon/32?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="48x48" href="/branding/favicon/48?v=<?= $brandingVersion ?>">
+    <link rel="icon" type="image/png" sizes="96x96" href="/branding/favicon/96?v=<?= $brandingVersion ?>">
+    <link rel="apple-touch-icon" sizes="180x180" href="/branding/favicon/180?v=<?= $brandingVersion ?>">
+    <link rel="manifest" href="/branding/manifest?v=<?= $brandingVersion ?>">
     <style>
         html, body { height: 100%; }
         body.auth-split {

--- a/src/Views/settings/index.php
+++ b/src/Views/settings/index.php
@@ -1549,56 +1549,40 @@ document.getElementById('oidcNewUserPolicy').addEventListener('change', function
 
         <form method="POST" action="/settings/branding" enctype="multipart/form-data" id="brandingForm">
             <input type="hidden" name="csrf_token" value="<?= $this->csrfToken() ?>">
+            <input type="hidden" name="branding_logo_data" id="brandingLogoData">
             <input type="hidden" name="branding_icon_data" id="brandingIconData">
-            <input type="hidden" name="branding_login_logo_data" id="brandingLoginLogoData">
+            <input type="hidden" name="branding_favicon_data" id="brandingFaviconData">
+            <input type="hidden" name="branding_favicon_ico_data" id="brandingFaviconIcoData">
 
-            <!-- Navbar Icon -->
             <div class="row mb-4">
                 <div class="col-md-8">
-                    <h6><i class="bi bi-image me-1"></i> Navbar Icon</h6>
-                    <p class="text-muted small">Square transparent PNG shown in the top-left corner. Will be resized to 120x120px max.</p>
-                    <input type="file" class="form-control form-control-sm" id="iconFileInput" accept="image/png">
-                    <div class="small text-muted mt-1" id="iconDimensions"></div>
-                    <?php if (!empty($settings['branding_icon'])): ?>
+                    <h6><i class="bi bi-image me-1"></i> Brand Logo</h6>
+                    <p class="text-muted small">Upload one PNG. BBS will create the navbar icon, login logo, browser favicons, Apple touch icon, and manifest icons.</p>
+                    <input type="file" class="form-control form-control-sm" id="brandLogoFileInput" accept="image/png">
+                    <div class="small text-muted mt-1" id="brandLogoDimensions"></div>
+                    <?php if (!empty($settings['branding_icon']) || !empty($settings['branding_login_logo'])): ?>
                     <div class="form-check mt-2">
                         <input class="form-check-input" type="checkbox" name="remove_branding_icon" value="1" id="removeBrandingIcon">
-                        <label class="form-check-label small" for="removeBrandingIcon">Remove custom icon (revert to default)</label>
+                        <label class="form-check-label small" for="removeBrandingIcon">Remove custom navbar icon and favicons</label>
                     </div>
-                    <?php endif; ?>
-                </div>
-                <div class="col-md-4 text-center">
-                    <label class="form-label small text-muted">Preview</label>
-                    <div class="p-3 rounded <?= ($_SESSION['theme'] ?? 'dark') === 'dark' ? 'bg-dark' : 'bg-body-secondary' ?>">
-                        <img id="iconPreview" src="<?= !empty($settings['branding_icon']) ? 'data:image/png;base64,' . $settings['branding_icon'] : '/images/borg_icon_dark.png' ?>" alt="Icon preview" style="height: 36px;">
-                        <?php if (empty($settings['branding_icon'])): ?>
-                        <div class="text-muted small mt-1" id="iconDefaultLabel">Default</div>
-                        <?php endif; ?>
-                    </div>
-                </div>
-            </div>
-
-            <hr>
-
-            <!-- Login Logo -->
-            <div class="row mb-4">
-                <div class="col-md-8">
-                    <h6><i class="bi bi-card-image me-1"></i> Login Page Logo</h6>
-                    <p class="text-muted small">Transparent PNG displayed on the login page. Will be resized to fit within 475 x 100 pixels.</p>
-                    <input type="file" class="form-control form-control-sm" id="loginLogoFileInput" accept="image/png">
-                    <div class="small text-muted mt-1" id="loginLogoDimensions"></div>
-                    <?php if (!empty($settings['branding_login_logo'])): ?>
                     <div class="form-check mt-2">
                         <input class="form-check-input" type="checkbox" name="remove_branding_login_logo" value="1" id="removeLoginLogo">
-                        <label class="form-check-label small" for="removeLoginLogo">Remove custom logo (revert to default)</label>
+                        <label class="form-check-label small" for="removeLoginLogo">Remove custom login logo</label>
                     </div>
                     <?php endif; ?>
                 </div>
-                <div class="col-md-4 text-center">
-                    <label class="form-label small text-muted">Preview</label>
+                <div class="col-md-4">
+                    <label class="form-label small text-muted">Previews</label>
                     <div class="p-3 rounded <?= ($_SESSION['theme'] ?? 'dark') === 'dark' ? 'bg-dark' : 'bg-body-secondary' ?>">
-                        <img id="loginLogoPreview" src="<?= !empty($settings['branding_login_logo']) ? 'data:image/png;base64,' . $settings['branding_login_logo'] : '/images/borg_icon_dark.png' ?>" alt="Login logo preview" style="<?= !empty($settings['branding_login_logo']) ? 'max-width:300px;max-height:80px;' : 'max-width:80px;' ?>">
+                        <div class="d-flex align-items-center justify-content-center gap-3 mb-3">
+                            <img id="iconPreview" src="<?= !empty($settings['branding_icon']) ? 'data:image/png;base64,' . $settings['branding_icon'] : '/images/borg_icon_dark.png' ?>" alt="Navbar icon preview" style="height: 36px;">
+                            <img id="faviconPreview" src="<?= !empty($settings['branding_favicon_32']) ? 'data:image/png;base64,' . $settings['branding_favicon_32'] : '/images/borg_icon_dark.png' ?>" alt="Favicon preview" style="width: 32px; height: 32px;">
+                        </div>
+                        <div class="text-center">
+                            <img id="loginLogoPreview" src="<?= !empty($settings['branding_login_logo']) ? 'data:image/png;base64,' . $settings['branding_login_logo'] : '/images/borg_icon_dark.png' ?>" alt="Login logo preview" style="<?= !empty($settings['branding_login_logo']) ? 'max-width:300px;max-height:80px;' : 'max-width:80px;' ?>">
+                        </div>
                         <?php if (empty($settings['branding_login_logo'])): ?>
-                        <div class="text-muted small mt-1" id="loginLogoDefaultLabel">Default</div>
+                        <div class="text-muted small mt-2 text-center" id="brandDefaultLabel">Default</div>
                         <?php endif; ?>
                     </div>
                 </div>
@@ -1625,53 +1609,127 @@ document.getElementById('oidcNewUserPolicy').addEventListener('change', function
     </div>
 </div>
 <script>
-function resizeImage(file, maxW, maxH, callback) {
+function loadImageFile(file, callback) {
     var reader = new FileReader();
     reader.onload = function(e) {
         var img = new Image();
         img.onload = function() {
-            var w = img.width, h = img.height;
-            if (w <= maxW && h <= maxH) {
-                // Already within limits, use original
-                callback(e.target.result, w, h);
-                return;
-            }
-            var ratio = Math.min(maxW / w, maxH / h);
-            var nw = Math.round(w * ratio), nh = Math.round(h * ratio);
-            var canvas = document.createElement('canvas');
-            canvas.width = nw;
-            canvas.height = nh;
-            var ctx = canvas.getContext('2d');
-            ctx.drawImage(img, 0, 0, nw, nh);
-            callback(canvas.toDataURL('image/png'), nw, nh);
+            callback(img);
         };
         img.src = e.target.result;
     };
     reader.readAsDataURL(file);
 }
 
-document.getElementById('iconFileInput').addEventListener('change', function() {
-    if (!this.files[0]) return;
-    resizeImage(this.files[0], 120, 120, function(dataUrl, w, h) {
-        document.getElementById('iconPreview').src = dataUrl;
-        document.getElementById('iconPreview').style.height = '36px';
-        document.getElementById('brandingIconData').value = dataUrl.split(',')[1];
-        document.getElementById('iconDimensions').textContent = 'Resized to ' + w + 'x' + h + 'px';
-        var lbl = document.getElementById('iconDefaultLabel');
-        if (lbl) lbl.style.display = 'none';
-    });
-});
+function renderContainedPng(img, width, height, options) {
+    options = options || {};
+    var padding = options.padding || 0;
+    var canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    var ctx = canvas.getContext('2d');
 
-document.getElementById('loginLogoFileInput').addEventListener('change', function() {
+    if (options.background) {
+        ctx.fillStyle = options.background;
+        ctx.fillRect(0, 0, width, height);
+    }
+
+    var maxW = width - padding * 2;
+    var maxH = height - padding * 2;
+    var ratio = Math.min(maxW / img.width, maxH / img.height, 1);
+    var drawW = Math.max(1, Math.round(img.width * ratio));
+    var drawH = Math.max(1, Math.round(img.height * ratio));
+    var x = Math.round((width - drawW) / 2);
+    var y = Math.round((height - drawH) / 2);
+    ctx.drawImage(img, x, y, drawW, drawH);
+
+    return {
+        dataUrl: canvas.toDataURL('image/png'),
+        width: drawW,
+        height: drawH
+    };
+}
+
+function base64ToBytes(base64) {
+    var binary = atob(base64);
+    var bytes = new Uint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+function bytesToBase64(bytes) {
+    var binary = '';
+    var chunkSize = 0x8000;
+    for (var i = 0; i < bytes.length; i += chunkSize) {
+        binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+    }
+    return btoa(binary);
+}
+
+function createIcoBase64(pngs) {
+    var entries = [16, 32, 48].map(function(size) {
+        return {size: size, bytes: base64ToBytes(pngs[size])};
+    });
+    var headerSize = 6 + entries.length * 16;
+    var totalSize = headerSize + entries.reduce(function(sum, entry) {
+        return sum + entry.bytes.length;
+    }, 0);
+    var buffer = new ArrayBuffer(totalSize);
+    var view = new DataView(buffer);
+    var out = new Uint8Array(buffer);
+    var offset = headerSize;
+
+    view.setUint16(0, 0, true);
+    view.setUint16(2, 1, true);
+    view.setUint16(4, entries.length, true);
+
+    entries.forEach(function(entry, index) {
+        var dir = 6 + index * 16;
+        view.setUint8(dir, entry.size);
+        view.setUint8(dir + 1, entry.size);
+        view.setUint8(dir + 2, 0);
+        view.setUint8(dir + 3, 0);
+        view.setUint16(dir + 4, 1, true);
+        view.setUint16(dir + 6, 32, true);
+        view.setUint32(dir + 8, entry.bytes.length, true);
+        view.setUint32(dir + 12, offset, true);
+        out.set(entry.bytes, offset);
+        offset += entry.bytes.length;
+    });
+
+    return bytesToBase64(out);
+}
+
+document.getElementById('brandLogoFileInput').addEventListener('change', function() {
     if (!this.files[0]) return;
-    resizeImage(this.files[0], 475, 100, function(dataUrl, w, h) {
-        var preview = document.getElementById('loginLogoPreview');
-        preview.src = dataUrl;
-        preview.style.maxWidth = '300px';
-        preview.style.maxHeight = '80px';
-        document.getElementById('brandingLoginLogoData').value = dataUrl.split(',')[1];
-        document.getElementById('loginLogoDimensions').textContent = 'Resized to ' + w + 'x' + h + 'px';
-        var lbl = document.getElementById('loginLogoDefaultLabel');
+    loadImageFile(this.files[0], function(img) {
+        var login = renderContainedPng(img, Math.min(img.width, 475), Math.min(img.height, 100));
+        if (img.width > 475 || img.height > 100) {
+            login = renderContainedPng(img, 475, 100);
+        }
+        var icon = renderContainedPng(img, 120, 120, {padding: 10});
+        var favicons = {};
+        [16, 32, 48, 96, 180, 192, 512].forEach(function(size) {
+            favicons[size] = renderContainedPng(img, size, size, {
+                padding: Math.max(0, Math.round(size * 0.12)),
+                background: size >= 180 ? '#1a1d21' : null
+            }).dataUrl.split(',')[1];
+        });
+
+        document.getElementById('loginLogoPreview').src = login.dataUrl;
+        document.getElementById('loginLogoPreview').style.maxWidth = '300px';
+        document.getElementById('loginLogoPreview').style.maxHeight = '80px';
+        document.getElementById('iconPreview').src = icon.dataUrl;
+        document.getElementById('faviconPreview').src = renderContainedPng(img, 32, 32, {padding: 4}).dataUrl;
+        document.getElementById('brandingLogoData').value = login.dataUrl.split(',')[1];
+        document.getElementById('brandingIconData').value = icon.dataUrl.split(',')[1];
+        document.getElementById('brandingFaviconData').value = JSON.stringify(favicons);
+        document.getElementById('brandingFaviconIcoData').value = createIcoBase64(favicons);
+        document.getElementById('brandLogoDimensions').textContent =
+            'Generated navbar 120x120, login ' + login.width + 'x' + login.height + ', favicon.ico, favicons 16/32/48/96/180/192/512.';
+        var lbl = document.getElementById('brandDefaultLabel');
         if (lbl) lbl.style.display = 'none';
     });
 });


### PR DESCRIPTION
## Summary

Closes #149.

This extends the branding workflow so a single uploaded PNG can generate and store the assets browsers expect today:

- navbar icon
- login page logo
- multi-size `favicon.ico` fallback
- PNG favicons for 16, 32, 48, and 96 px
- Apple touch icon at 180 px
- web app manifest icons at 192 and 512 px

It also serves branding icons through dynamic routes with a `branding_version` cache-busting value, updates the app/auth layouts to reference those routes, and points the manifest icon entries at the generated branding favicon endpoints.

## Why

Issue #149 asked for favicon support. While a static favicon would cover browser tabs, the current branding feature already lets admins upload custom logos, so this PR makes favicon generation part of the same branding flow.

## Data model

The generated 512x512 PNG can exceed the existing `TEXT` limit in `settings.value`, so this adds migration `081_settings_value_mediumtext.sql` and updates `schema.sql` to use `MEDIUMTEXT`.

## Maintainer note

This is intentionally more than a tiny static favicon patch. It touches routing, settings persistence, branding upload UI, layouts, the manifest, and the settings schema. I would recommend testing it carefully before opening this particular Pandora's box in a release.

The author reports manual testing on two installations, one Docker-based and one standalone, with the current behavior working well in both.

## Validation

- `php -l src/Controllers/SettingsController.php`
- `php -l src/Core/App.php`
- `php -l src/Views/settings/index.php`
- `php -l src/Views/layouts/app.php`
- `php -l src/Views/layouts/auth.php`
- Manual branding upload test on Docker install
- Manual branding upload test on standalone install

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows
