### PR TITLE
fix(scheduler): don't overwrite abandoned server-side job with completed (#227)

### DIFF
--- a/scheduler.php
+++ b/scheduler.php
@@ -1444,20 +1444,54 @@ foreach ($serverJobs as $sj) {
     }
 
     $now = date('Y-m-d H:i:s');
-    $db->update('backup_jobs', [
-        'status' => $result,
-        'completed_at' => $now,
-        'duration_seconds' => max(0, strtotime($now) - strtotime($startedAt)),
-        'error_log' => $errorOutput ?: null,
-    ], 'id = ?', [$sj['id']]);
+    // Only overwrite the row if it's still 'running'. The status() endpoint
+    // (AgentApiController) can transition a 'running' server-side job to
+    // 'failed' mid-flight when the agent reports `abandoned` after a stall,
+    // and we must not clobber that terminal status with our own
+    // 'completed'/'failed'. Without this guard the dashboard ends up
+    // showing the job as a green "Recently Completed" entry even though
+    // the activity log already recorded the abandon (issue #227).
+    $finalize = $db->query(
+        "UPDATE backup_jobs
+            SET status = ?, completed_at = ?, duration_seconds = ?, error_log = ?
+          WHERE id = ? AND status = 'running'",
+        [
+            $result,
+            $now,
+            max(0, strtotime($now) - strtotime($startedAt)),
+            $errorOutput ?: null,
+            $sj['id'],
+        ]
+    );
 
-    $level = $result === 'completed' ? 'info' : 'error';
-    $db->insert('server_log', [
-        'agent_id' => $sj['agent_id'],
-        'backup_job_id' => $sj['id'],
-        'level' => $level,
-        'message' => "Server-side {$sj['task_type']} job #{$sj['id']} {$result}" . ($errorOutput ? ": $errorOutput" : ''),
-    ]);
+    if ($finalize->rowCount() === 0) {
+        // Someone else (typically the abandoned report) already terminated
+        // this job. Log a warning, force `$result` to 'failed' so the
+        // post-completion hooks below (archive deletion, repo-size refresh,
+        // S3 auto-queue) don't act as if the run succeeded, and skip the
+        // misleading "Server-side {type} job #{id} completed" log.
+        $existing = $db->fetchOne(
+            "SELECT status, error_log FROM backup_jobs WHERE id = ?",
+            [$sj['id']]
+        );
+        $existingStatus = $existing['status'] ?? 'unknown';
+        $db->insert('server_log', [
+            'agent_id' => $sj['agent_id'],
+            'backup_job_id' => $sj['id'],
+            'level' => 'warning',
+            'message' => "Server-side {$sj['task_type']} job #{$sj['id']} finished, but its status was already '{$existingStatus}' (likely an abandoned/cancelled report came in mid-flight); not overwriting.",
+        ]);
+        echo date('Y-m-d H:i:s') . " Server-side {$sj['task_type']} job #{$sj['id']}: finished but already '{$existingStatus}'; not overwriting status\n";
+        $result = 'failed';
+    } else {
+        $level = $result === 'completed' ? 'info' : 'error';
+        $db->insert('server_log', [
+            'agent_id' => $sj['agent_id'],
+            'backup_job_id' => $sj['id'],
+            'level' => $level,
+            'message' => "Server-side {$sj['task_type']} job #{$sj['id']} {$result}" . ($errorOutput ? ": $errorOutput" : ''),
+        ]);
+    }
 
     // Log borg prune/compact output for visibility
     if ($result === 'completed' && !empty($stdout)) {


### PR DESCRIPTION
## Summary

Closes #227.

When the agent reports \`abandoned\` for a server-side task while the scheduler is mid-run, two updates race over the same \`backup_jobs\` row:

1. The scheduler's \`Step 4b\` foreach atomically claims a \`'sent'\` server-side job, transitions it to \`'running'\`, and shells out to \`borg\` (or \`rclone\`, etc.). For \`archive_delete\` on a moderately full repo this can take well over an hour.
2. While the shell is still executing the agent stall detector hits \`/agent/status\` with \`result=abandoned\`. \`AgentApiController::status()\` sees the job as \`'running'\` (not in the \`['completed','failed','cancelled']\` idempotency list), so it transitions it to \`'failed'\` with the *Job abandoned…* error_log.
3. The scheduler's borg invocation eventually returns. The unconditional \`db->update(..., ['status' => \$result, ...])\` at the bottom of the loop then **clobbers** the just-set \`'failed'\` with \`'completed'\`, and emits the misleading \`Server-side {type} job #{id} completed\` server_log entry.

That is exactly the conflicting log pair shown in #227, and why the *Recently Completed* dashboard card shows the abandoned archive_delete with a green check + ~1h15 duration.

## Fix

Gate the finalize update on \`WHERE status = 'running'\`. If another path has already terminated the row, the update affects 0 rows and we:

- log a \`warning\`-level \`server_log\` entry naming the existing terminal status, instead of the misleading *completed* line;
- flip the local \`\$result\` to \`'failed'\` so the post-completion branches further down the loop (archive deletion, repo-size refresh, S3 auto-queue) don't run as if the borg op succeeded.

The atomic \`started_at\` claim at line 282 was already using this exact pattern for the queued→running transition; this just extends the same idea to the running→terminal transition.

## Out of scope

A symmetric race exists for \`s3_sync\` at line ~340 (its own update path with the same shape), but tackling that means revisiting \`last_sync_at\`, notification, and manifest-upload side effects. Left for a follow-up.

## Test plan

- [x] \`php -l scheduler.php\` — clean
- [ ] Manual Docker repro (couldn't run a full stack here): queue an \`archive_delete\` on a slow repo, kill the agent during execution, wait for the stall detector, observe the server_log no longer contains a \"Server-side archive_delete job #N completed\" line and the dashboard shows the job under failures rather than recent completions.

The change is purely defensive — it removes a write, never adds one — and matches the established pattern at line 282.