### PR TITLE
Bug/fix remote SSH repository size accounting

### DIFF
--- a/scheduler.php
+++ b/scheduler.php
@@ -1576,8 +1576,8 @@ foreach ($serverJobs as $sj) {
                 ]);
             }
             // Refresh archive count + size. Prune just shrank the repo,
-            // so measure actual disk usage now (local) or re-sum archives
-            // (remote SSH) — see RepositorySizeService.
+            // so measure actual disk usage now; remote SSH falls back to
+            // archive dedup totals only if du is unavailable.
             $db->query(
                 "UPDATE repositories SET archive_count = (SELECT COUNT(*) FROM archives WHERE repository_id = ?) WHERE id = ?",
                 [$repoId, $repoId]

--- a/src/Controllers/Api/AgentApiController.php
+++ b/src/Controllers/Api/AgentApiController.php
@@ -427,7 +427,7 @@ class AgentApiController extends Controller
             ]);
 
             // Update archive count + borg version. Size is refreshed below
-            // via RepositorySizeService (du for local, SUM for remote SSH) —
+            // via RepositorySizeService (du locally or over remote SSH) —
             // runs once per backup instead of a periodic scan, so idle disks
             // stay idle.
             $borgVer = !empty($agent['borg_version']) ? preg_replace('/^borg\s+/', '', $agent['borg_version']) : null;

--- a/src/Services/RemoteSshService.php
+++ b/src/Services/RemoteSshService.php
@@ -326,6 +326,88 @@ class RemoteSshService
     }
 
     /**
+     * Measure a single remote borg repository directory with du -sk.
+     * Returns bytes used on disk, or null if the path cannot be measured.
+     */
+    public function getRepositorySizeBytes(array $config, string $repoPath): ?int
+    {
+        $remotePath = $this->remoteFilesystemPathFromRepoUrl($repoPath);
+        if ($remotePath === null || $remotePath === '' || str_contains($remotePath, "\0")) {
+            return null;
+        }
+
+        $keyFile = null;
+        try {
+            $sshKey = $this->decryptKey($config);
+            $keyFile = $this->writeTempKey($sshKey);
+
+            $port = (int) ($config['remote_port'] ?? 22);
+            $sshCmd = [
+                'ssh',
+                '-i', $keyFile,
+                '-p', (string) $port,
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'UserKnownHostsFile=/dev/null',
+                '-o', 'BatchMode=yes',
+                '-o', 'LogLevel=ERROR',
+                '-o', 'ConnectTimeout=30',
+                "{$config['remote_user']}@{$config['remote_host']}",
+                'du -sk -- ' . escapeshellarg($remotePath),
+            ];
+
+            $proc = proc_open($sshCmd, [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ], $pipes, null, $this->buildServerEnv());
+
+            if (!is_resource($proc)) {
+                return null;
+            }
+
+            fclose($pipes[0]);
+            $stdout = trim(stream_get_contents($pipes[1]));
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $exitCode = proc_close($proc);
+
+            if ($exitCode !== 0 || $stdout === '') {
+                return null;
+            }
+
+            $fields = preg_split('/\s+/', $stdout);
+            $kib = isset($fields[0]) && is_numeric($fields[0]) ? (int) $fields[0] : 0;
+            return $kib > 0 ? $kib * 1024 : 0;
+        } catch (\Exception $e) {
+            return null;
+        } finally {
+            $this->cleanupTempKey($keyFile);
+        }
+    }
+
+    /**
+     * Convert ssh://user@host/./repo into ./repo and ssh://host//abs/repo into /abs/repo.
+     */
+    private function remoteFilesystemPathFromRepoUrl(string $repoPath): ?string
+    {
+        if (!str_starts_with($repoPath, 'ssh://')) {
+            return $repoPath;
+        }
+
+        $path = parse_url($repoPath, PHP_URL_PATH);
+        if (!is_string($path) || $path === '') {
+            return null;
+        }
+
+        $path = rawurldecode($path);
+        if (str_starts_with($path, '//')) {
+            return '/' . ltrim($path, '/');
+        }
+
+        return ltrim($path, '/');
+    }
+
+    /**
      * Decrypt the SSH private key from a config record.
      */
     private function decryptKey(array $config): string

--- a/src/Services/RepositorySizeService.php
+++ b/src/Services/RepositorySizeService.php
@@ -8,8 +8,9 @@ use BBS\Core\Database;
  * Refreshes repositories.size_bytes after events that actually change repo
  * size: backup completion, prune, compact, and archive_delete.
  *
- * Runs `du` on local repos via bbs-ssh-helper, or falls back to
- * SUM(archives.deduplicated_size) for remote SSH repos where we can't du.
+ * Runs `du` on local repos via bbs-ssh-helper, or over SSH for remote SSH
+ * repos. If a remote repo can't be measured, falls back to
+ * SUM(archives.deduplicated_size).
  *
  * Previously a scheduler loop ran `du` on every local repo every 5 minutes,
  * which kept spinning disks awake on idle home servers. Now disks are only
@@ -24,13 +25,20 @@ class RepositorySizeService
         if (!$repo) return;
 
         if (($repo['storage_type'] ?? 'local') === 'remote_ssh') {
-            // Can't du a remote SSH repo — fall back to SUM of deduplicated sizes.
-            $db->query(
-                "UPDATE repositories SET size_bytes = COALESCE(
-                    (SELECT SUM(deduplicated_size) FROM archives WHERE repository_id = ?), 0
-                ) WHERE id = ?",
-                [$repoId, $repoId]
-            );
+            $configId = (int) ($repo['remote_ssh_config_id'] ?? 0);
+            $config = $configId > 0
+                ? $db->fetchOne("SELECT * FROM remote_ssh_configs WHERE id = ?", [$configId])
+                : null;
+
+            if ($config) {
+                $remoteSize = (new RemoteSshService())->getRepositorySizeBytes($config, $repo['path']);
+                if ($remoteSize !== null) {
+                    $db->update('repositories', ['size_bytes' => $remoteSize], 'id = ?', [$repoId]);
+                    return;
+                }
+            }
+
+            self::refreshFromArchiveDedup($repoId);
             return;
         }
 
@@ -42,5 +50,16 @@ class RepositorySizeService
         if (!empty($output[0]) && is_numeric($output[0])) {
             $db->update('repositories', ['size_bytes' => (int) $output[0]], 'id = ?', [$repoId]);
         }
+    }
+
+    private static function refreshFromArchiveDedup(int $repoId): void
+    {
+        $db = Database::getInstance();
+        $db->query(
+            "UPDATE repositories SET size_bytes = COALESCE(
+                (SELECT SUM(deduplicated_size) FROM archives WHERE repository_id = ?), 0
+            ) WHERE id = ?",
+            [$repoId, $repoId]
+        );
     }
 }


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does and why -->

## Changes

- measure remote SSH repository size using `du -sk` on the remote host
- keep `SUM(archives.deduplicated_size)` only as a fallback when remote measurement is unavailable
- update comments around repository size refresh behavior

## Root Cause
Remote SSH repositories previously used `SUM(archives.deduplicated_size)` to populate `repositories.size_bytes`.

That value is Borg's deduplicated archive data total, not the real filesystem space occupied by the repository directory. Because of that, the UI could show a much smaller value than the actual remote repository size.

Example from testing:

<img width="1591" height="221" alt="Screenshot from 2026-05-05 00-50-34" src="https://github.com/user-attachments/assets/5957d10c-df8d-416e-be1c-78656eaac1b1" />

- old displayed value: `98.3 GB`

<img width="1598" height="257" alt="Screenshot from 2026-05-05 01-15-13" src="https://github.com/user-attachments/assets/35f95cf6-9b26-4740-a394-81f51f14eea2" />

- refreshed value after this change: `684.1 GB`
_The repository size discrepancy is still visible, but it accurately represents reality, as backup jobs are executed at different times._ 

## Why This Is More Correct
For local repositories, BBS already treats repository size as actual disk usage by running `du` against the repository directory.

Remote SSH repositories should follow the same meaning. The user-facing "repository size" should answer: how much storage does this repository occupy on the target filesystem?

`SUM(archives.deduplicated_size)` answers a different question: how much deduplicated archive payload Borg reports. It does not include all repository metadata, indexes, segment files, retained/uncompacted data, filesystem allocation effects, and other on-disk overhead. For capacity planning and storage monitoring, that number is misleading.

Running `du -sk` remotely makes local and remote repository size semantics consistent: both now report real filesystem usage. The archive dedup sum remains as a safe fallback if SSH measurement fails.

## Testing
- [x] `php -l src/Services/RemoteSshService.php`
- [x] `php -l src/Services/RepositorySizeService.php`
- [x] `php -l src/Controllers/Api/AgentApiController.php`
- [x] `php -l scheduler.php`
- [x] Tested on Docker
- [x] Tested on bare metal
