### PR TITLE
Fix dark card background in stats tile

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -997,7 +997,6 @@ body.bg-body-secondary {
 [data-bs-theme="dark"] .card {
     border: 1px solid rgba(255, 255, 255, 0.05) !important;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-    background-color: #111214;
 }
 
 [data-bs-theme="dark"] .card-header {


### PR DESCRIPTION
## Summary

Removes the forced dark-mode card background color so cards inherit the themed Bootstrap background.

## Why

Fixes #244. The Stats tile could show a black block below the table content in dark mode because `.card` was forced to `#111214`, making the unused card area visually different from the table area.

## Changes

- Removed `background-color: #111214;` from `[data-bs-theme="dark"] .card`.

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [X] Tested on Docker
- [X] Tested on bare metal

