### PR TITLE
Improve schedule error state styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -65,6 +65,7 @@ a.metric-tile:hover { transform: translateY(-1px); filter: brightness(1.1); }
 /* Font & nav color variables */
 :root {
     --bs-body-font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    --bs-box-shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.375);
     --bbs-nav-bg: #2c3e50;
     --bbs-nav-color: rgba(255, 255, 255, 0.7);
     --bbs-nav-hover-bg: rgba(255, 255, 255, 0.1);

--- a/src/Controllers/ScheduleController.php
+++ b/src/Controllers/ScheduleController.php
@@ -216,7 +216,7 @@ class ScheduleController extends Controller
         if (!empty($planIds)) {
             $placeholders = implode(',', array_fill(0, count($planIds), '?'));
             $rows = $this->db->fetchAll("
-                SELECT backup_plan_id, status, completed_at
+                SELECT id, backup_plan_id, status, completed_at
                 FROM backup_jobs
                 WHERE backup_plan_id IN ({$placeholders})
                   AND task_type = 'backup'
@@ -228,6 +228,7 @@ class ScheduleController extends Controller
                 $pid = (int) $r['backup_plan_id'];
                 if (!isset($latestJobs[$pid])) {
                     $latestJobs[$pid] = [
+                        'id' => (int) $r['id'],
                         'status' => $r['status'],
                         'completed_at' => $r['completed_at'],
                     ];
@@ -319,6 +320,7 @@ class ScheduleController extends Controller
                         'time_label' => $is24h ? $schedDate->format('H:i') : $schedDate->format('g:i A'),
                         'scheduled_at_utc' => (clone $schedDate)->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
                         'job_status' => null,
+                        'failed_job_id' => null,
                         'has_error' => false,
                     ];
                 }
@@ -342,6 +344,7 @@ class ScheduleController extends Controller
 
             if ($bestIdx !== null) {
                 $blocks[$bestIdx]['job_status'] = 'failed';
+                $blocks[$bestIdx]['failed_job_id'] = (int) $job['id'];
                 $blocks[$bestIdx]['has_error'] = true;
             }
         }

--- a/src/Controllers/ScheduleController.php
+++ b/src/Controllers/ScheduleController.php
@@ -210,6 +210,31 @@ class ScheduleController extends Controller
             }
         }
 
+        // Latest terminal backup result per plan. Duration estimates still use
+        // successful jobs only; this is presentation state for completed blocks.
+        $latestJobs = [];
+        if (!empty($planIds)) {
+            $placeholders = implode(',', array_fill(0, count($planIds), '?'));
+            $rows = $this->db->fetchAll("
+                SELECT backup_plan_id, status, completed_at
+                FROM backup_jobs
+                WHERE backup_plan_id IN ({$placeholders})
+                  AND task_type = 'backup'
+                  AND status IN ('completed', 'failed')
+                  AND completed_at IS NOT NULL
+                ORDER BY completed_at DESC
+            ", $planIds);
+            foreach ($rows as $r) {
+                $pid = (int) $r['backup_plan_id'];
+                if (!isset($latestJobs[$pid])) {
+                    $latestJobs[$pid] = [
+                        'status' => $r['status'],
+                        'completed_at' => $r['completed_at'],
+                    ];
+                }
+            }
+        }
+
         // User timezone for displaying schedules in the viewer's local time
         $userTz = $_SESSION['timezone'] ?? 'America/New_York';
         $is24h  = \BBS\Core\TimeHelper::is24h();
@@ -292,8 +317,32 @@ class ScheduleController extends Controller
                         'estimated' => $estimated,
                         'frequency' => $s['frequency'],
                         'time_label' => $is24h ? $schedDate->format('H:i') : $schedDate->format('g:i A'),
+                        'scheduled_at_utc' => (clone $schedDate)->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+                        'job_status' => null,
+                        'has_error' => false,
                     ];
                 }
+            }
+        }
+
+        foreach ($latestJobs as $planId => $job) {
+            if (($job['status'] ?? '') !== 'failed') continue;
+            $completedTs = strtotime($job['completed_at'] ?? '') ?: 0;
+            $bestIdx = null;
+            $bestTs = null;
+
+            foreach ($blocks as $idx => $block) {
+                if ((int) $block['plan_id'] !== (int) $planId) continue;
+                $scheduledTs = strtotime($block['scheduled_at_utc'] ?? '') ?: 0;
+                if ($scheduledTs <= $completedTs && ($bestTs === null || $scheduledTs > $bestTs)) {
+                    $bestIdx = $idx;
+                    $bestTs = $scheduledTs;
+                }
+            }
+
+            if ($bestIdx !== null) {
+                $blocks[$bestIdx]['job_status'] = 'failed';
+                $blocks[$bestIdx]['has_error'] = true;
             }
         }
 

--- a/src/Views/dashboard/index.php
+++ b/src/Views/dashboard/index.php
@@ -93,7 +93,7 @@ $dfFix = function (string $s): string {
     align-items: center;
     justify-content: center;
     color: #fff;
-    text-shadow: 0 0 3px rgba(0,0,0,0.7), 0 0 1px rgba(0,0,0,0.9);
+    text-shadow: 0 2px 3px rgba(0,0,0,0.9), 0 2px 6px rgba(0,0,0,0.9);
     pointer-events: none;
 }
 /* Right column also fixed-width so the bar's right edge is consistent

--- a/src/Views/schedules/week.php
+++ b/src/Views/schedules/week.php
@@ -122,10 +122,13 @@ function bbs_histogram_ticks(int $max): array
     --schedule-error-ink: #fff3f4;
     --schedule-error-crack: rgba(70, 6, 14, 0.5);
     --schedule-error-cracked:
-        linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(65, 4, 12, 0.34)),
-        linear-gradient(28deg, transparent 0 36%, var(--schedule-error-crack) 36% 37.5%, transparent 37.5% 100%),
-        linear-gradient(148deg, transparent 0 62%, rgba(255, 210, 214, 0.32) 62% 63%, transparent 63% 100%),
-        repeating-linear-gradient(112deg, transparent 0 16px, rgba(78, 0, 12, 0.28) 16px 17px, transparent 17px 31px),
+        linear-gradient(135deg, rgba(255, 255, 255, 0.14), rgba(65, 4, 12, 0.46)),
+        linear-gradient(23deg, transparent 0 18%, rgba(255, 205, 210, 0.42) 18% 19%, transparent 19% 100%),
+        linear-gradient(31deg, transparent 0 35%, var(--schedule-error-crack) 35% 38%, transparent 38% 100%),
+        linear-gradient(151deg, transparent 0 58%, rgba(255, 210, 214, 0.42) 58% 59.5%, transparent 59.5% 100%),
+        linear-gradient(104deg, transparent 0 44%, rgba(50, 0, 8, 0.5) 44% 46%, transparent 46% 100%),
+        repeating-linear-gradient(112deg, transparent 0 10px, rgba(78, 0, 12, 0.42) 10px 12px, transparent 12px 23px),
+        repeating-linear-gradient(36deg, transparent 0 18px, rgba(255, 195, 200, 0.18) 18px 19px, transparent 19px 37px),
         linear-gradient(135deg, var(--schedule-error-bg), var(--schedule-error-bg-2));
 }
 [data-bs-theme="dark"] {
@@ -151,6 +154,7 @@ function bbs_histogram_ticks(int $max): array
     color-scheme: light dark;
 }
 .hist-container {
+    --hist-axis-offset: 56px;
     position: relative;
     height: 170px;
     display: block;
@@ -161,7 +165,7 @@ function bbs_histogram_ticks(int $max): array
     position: absolute;
     top: 0;
     bottom: 18px; /* match bar-wrap padding-bottom so we don't draw over the x-labels */
-    left: 56px;   /* start after the yaxis column */
+    left: var(--hist-axis-offset);   /* start after the yaxis column */
     right: 0;
     pointer-events: none;
     z-index: 1;
@@ -273,7 +277,7 @@ function bbs_histogram_ticks(int $max): array
     position: absolute;
     top: 8px;
     bottom: 22px;
-    left: 56px;
+    left: var(--hist-axis-offset);
     right: 0;
     z-index: 2;
 }
@@ -344,7 +348,8 @@ function bbs_histogram_ticks(int $max): array
     position: absolute;
     top: 0;
     bottom: 18px;
-    left: 56px;
+    left: var(--hist-axis-offset);
+    width: calc((100% - var(--hist-axis-offset)) * var(--now-pct, 0));
     z-index: 0;
     pointer-events: none;
     background:
@@ -354,7 +359,7 @@ function bbs_histogram_ticks(int $max): array
 }
 .hist-xaxis {
     position: absolute;
-    left: 56px;
+    left: var(--hist-axis-offset);
     right: 0;
     bottom: 0;
     height: 16px;
@@ -782,8 +787,9 @@ function bbs_histogram_ticks(int $max): array
     }
     .day-block {
         gap: 0;
-        padding: 0;
+        padding: 0 4px 0 0;
         min-width: 6px;
+        border-left: 1px solid var(--agent-accent);
         touch-action: manipulation;
         -webkit-tap-highlight-color: transparent;
     }
@@ -792,10 +798,28 @@ function bbs_histogram_ticks(int $max): array
         width: 6px;
         height: auto;
         border-radius: 0;
-        margin: 0;
+        margin: 0 3px 0 0;
     }
-    .day-block .agent,
+    .day-block .agent {
+        display: block;
+        flex: 1 1 auto;
+        max-width: none;
+        min-width: 0;
+        font-size: 0.62rem;
+        line-height: 1;
+    }
     .day-block .side {
+        display: none;
+    }
+}
+
+/* Phone-only: keep the backup timeline compact; tablets retain labels/axis. */
+@media (max-width: 575.98px) {
+    .hist-container {
+        --hist-axis-offset: 0px;
+    }
+    .hist-current-time-line .current-time-label,
+    .hist-timeline-axis {
         display: none;
     }
 }
@@ -883,9 +907,9 @@ function bbs_histogram_ticks(int $max): array
                 <?php if ($dIdx === $todayIdx): ?>
                     <?php $nowLeftPct = ($currentMinuteOfDay / 1440) * 100; ?>
                     <div class="hist-time-trail"
-                         style="width: calc((100% - 56px) * <?= $nowLeftPct / 100 ?>);"></div>
+                         style="--now-pct: <?= $nowLeftPct / 100 ?>;"></div>
                     <div class="hist-current-time-line <?= $nowLeftPct > 80 ? 'near-end' : '' ?>"
-                         style="left: calc(56px + ((100% - 56px) * <?= $nowLeftPct / 100 ?>));"
+                         style="left: calc(var(--hist-axis-offset) + ((100% - var(--hist-axis-offset)) * <?= $nowLeftPct / 100 ?>));"
                          title="Current time in <?= htmlspecialchars($userTz) ?>">
                         <span class="current-time-label">Time now: <?= htmlspecialchars($currentTimeLabel) ?></span>
                     </div>
@@ -914,6 +938,7 @@ function bbs_histogram_ticks(int $max): array
                              data-duration="<?= htmlspecialchars($timelineDurLabel) ?>"
                              data-frequency="<?= htmlspecialchars($b['frequency']) ?>"
                              data-job-status="<?= htmlspecialchars($b['job_status'] ?? '') ?>"
+                             data-failed-job-id="<?= (int) ($b['failed_job_id'] ?? 0) ?>"
                              style="top: <?= $laneTop ?>px; left: <?= round($startPct, 4) ?>%; width: max(var(--timeline-block-min-width, 46px), <?= round($durationPct, 4) ?>%); max-width: calc(100% - <?= round($startPct, 4) ?>%); --agent-accent: <?= bbs_agent_color((int) $b['agent_id']) ?>; --past-pct: <?= round($timelinePastPct, 2) ?>%;">
                         </div>
                     <?php endforeach; ?>
@@ -1022,6 +1047,7 @@ function bbs_histogram_ticks(int $max): array
                              data-duration="<?= htmlspecialchars($durLabel) ?>"
                              data-estimated="<?= $b['estimated'] ? '1' : '0' ?>"
                              data-job-status="<?= htmlspecialchars($b['job_status'] ?? '') ?>"
+                             data-failed-job-id="<?= (int) ($b['failed_job_id'] ?? 0) ?>"
                              style="top: <?= $top ?>px; height: <?= $height ?>px; left: calc(<?= $left ?>% + 4px); width: calc(<?= $laneWidth ?>% - 8px); --agent-accent: <?= $color ?>; --past-pct: <?= round($pastPct, 2) ?>%;">
                             <div class="agent"><?= htmlspecialchars($b['agent_name']) ?></div>
                             <div class="side">
@@ -1098,6 +1124,9 @@ function bbs_histogram_ticks(int $max): array
 
 <!-- Block context menu -->
 <div id="sched-ctxmenu" class="sched-ctxmenu">
+    <button type="button" id="ctx-retry" style="display: none;">
+        <i class="bi bi-arrow-repeat"></i><span>Retry</span>
+    </button>
     <button type="button" id="ctx-change-time">
         <i class="bi bi-clock"></i><span>Change Time</span>
     </button>
@@ -1258,6 +1287,7 @@ document.addEventListener('DOMContentLoaded', function () {
     function openScheduleContext(el, point) {
         ctxScheduleId = Number(el.dataset.scheduleId);
         ctxAgentId = Number(el.dataset.agentId);
+        ctxFailedJobId = el.dataset.jobStatus === 'failed' ? Number(el.dataset.failedJobId || 0) : null;
         hideTooltip();
         openCtxMenu(point);
     }
@@ -1317,17 +1347,16 @@ document.addEventListener('DOMContentLoaded', function () {
         seg.addEventListener('click', ev => {
             ev.preventDefault();
             ev.stopPropagation();
-            ctxScheduleId = Number(seg.dataset.scheduleId);
-            ctxAgentId = Number(seg.dataset.agentId);
-            hideTooltip();
-            openCtxMenu(ev);
+            openScheduleContext(seg, ev);
         });
     });
 
     // ----------------- Context menu ----------------------------------------
     const ctx = document.getElementById('sched-ctxmenu');
+    const ctxRetry = document.getElementById('ctx-retry');
     let ctxScheduleId = null;
     let ctxAgentId = null;
+    let ctxFailedJobId = null;
 
     document.querySelectorAll('.day-block').forEach(b => {
         b.addEventListener('click', ev => {
@@ -1347,6 +1376,9 @@ document.addEventListener('DOMContentLoaded', function () {
     });
 
     function openCtxMenu(ev) {
+        if (ctxRetry) {
+            ctxRetry.style.display = ctxFailedJobId ? 'flex' : 'none';
+        }
         ctx.style.display = 'block';
         let x = ev.clientX, y = ev.clientY;
         const rect = ctx.getBoundingClientRect();
@@ -1361,6 +1393,19 @@ document.addEventListener('DOMContentLoaded', function () {
         if (isMobileScheduleMode() && !ev.target.closest('.day-block') && !ev.target.closest('.hist-seg')) hideTooltip();
     });
     document.addEventListener('keydown', ev => { if (ev.key === 'Escape') { closeCtxMenu(); hideTooltip(); } });
+
+    ctxRetry.addEventListener('click', () => {
+        if (!ctxFailedJobId) return;
+        if (!confirm('Retry this failed job?')) return;
+        const f = document.createElement('form');
+        f.method = 'POST';
+        f.action = '/queue/' + ctxFailedJobId + '/retry';
+        const c = document.createElement('input');
+        c.type = 'hidden'; c.name = 'csrf_token'; c.value = csrfToken;
+        f.appendChild(c);
+        document.body.appendChild(f);
+        f.submit();
+    });
 
     document.getElementById('ctx-edit-plan').addEventListener('click', () => {
         if (!ctxScheduleId) return;

--- a/src/Views/schedules/week.php
+++ b/src/Views/schedules/week.php
@@ -155,6 +155,7 @@ function bbs_histogram_ticks(int $max): array
 }
 .hist-container {
     --hist-axis-offset: 56px;
+    --timeline-block-min-width: 46px;
     position: relative;
     height: 170px;
     display: block;
@@ -253,6 +254,7 @@ function bbs_histogram_ticks(int $max): array
     flex: 1 1 0;
     min-height: 6px;
     cursor: pointer;
+    touch-action: manipulation;
     background:
         linear-gradient(90deg, var(--agent-accent), rgba(255, 255, 255, 0.24) 8%, transparent 26%),
         linear-gradient(180deg, var(--schedule-laser-hot), var(--schedule-block-bg));
@@ -284,7 +286,7 @@ function bbs_histogram_ticks(int $max): array
 .hist-event {
     position: absolute;
     height: 24px;
-    min-width: var(--timeline-block-min-width, 46px);
+    min-width: var(--timeline-block-min-width);
     padding: 0;
     border-radius: 5px;
     border-left: 3px solid var(--agent-accent);
@@ -334,6 +336,7 @@ function bbs_histogram_ticks(int $max): array
         repeating-linear-gradient(45deg, var(--schedule-concrete-line) 0 1px, transparent 1px 6px),
         linear-gradient(180deg, var(--schedule-concrete-bg), var(--schedule-concrete-bg-2));
     border-left: 5px solid var(--agent-accent);
+    z-index: -1;
 }
 .hist-seg.is-error.is-past {
     background: var(--schedule-error-cracked);
@@ -813,6 +816,20 @@ function bbs_histogram_ticks(int $max): array
     }
 }
 
+/* Tablet/medium: keep backup timeline blocks proportional without the desktop minimum. */
+@media (min-width: 768px) and (max-width: 1199.98px) {
+    .hist-container {
+        --hist-axis-offset: 0px;
+        --timeline-block-min-width: 1px;
+    }
+    .hist-timeline-axis {
+        display: none;
+    }
+    .hist-event {
+        min-width: var(--timeline-block-min-width, 1px);
+    }
+}
+
 /* Phone-only: keep the backup timeline compact; tablets retain labels/axis. */
 @media (max-width: 575.98px) {
     .hist-container {
@@ -920,10 +937,17 @@ function bbs_histogram_ticks(int $max): array
                     <?php foreach ($blocksByDay[$dIdx] as $b): ?>
                         <?php
                         $startPct = max(0, min(100, ($b['start_min'] / 1440) * 100));
-                        $durationPct = max(0.25, min(100, ($b['duration_min'] / 1440) * 100));
+                        $actualDurationPct = max(0.001, min(100, ($b['duration_min'] / 1440) * 100));
+                        $durationPct = max(0.25, $actualDurationPct);
                         $laneTop = (int) ($b['lane'] ?? 0) * 30;
                         $timelinePastPct = bbs_schedule_progress_pct((int) $b['day_idx'], (int) $b['start_min'], (int) $b['duration_min'], $todayIdx, $currentMinuteOfDay);
                         $timelinePhase = bbs_day_block_phase($timelinePastPct);
+                        $timelineWidthPct = ((int) $b['day_idx'] === $todayIdx && $timelinePhase !== 'future')
+                            ? $actualDurationPct
+                            : $durationPct;
+                        $timelineMinWidth = ((int) $b['day_idx'] === $todayIdx && $timelinePhase !== 'future')
+                            ? '0px'
+                            : null;
                         $timelineIsError = !empty($b['has_error']);
                         $timelineDurLabel = $b['duration_min'] >= 60
                             ? floor($b['duration_min'] / 60) . 'h ' . ($b['duration_min'] % 60) . 'm'
@@ -939,7 +963,7 @@ function bbs_histogram_ticks(int $max): array
                              data-frequency="<?= htmlspecialchars($b['frequency']) ?>"
                              data-job-status="<?= htmlspecialchars($b['job_status'] ?? '') ?>"
                              data-failed-job-id="<?= (int) ($b['failed_job_id'] ?? 0) ?>"
-                             style="top: <?= $laneTop ?>px; left: <?= round($startPct, 4) ?>%; width: max(var(--timeline-block-min-width, 46px), <?= round($durationPct, 4) ?>%); max-width: calc(100% - <?= round($startPct, 4) ?>%); --agent-accent: <?= bbs_agent_color((int) $b['agent_id']) ?>; --past-pct: <?= round($timelinePastPct, 2) ?>%;">
+                             style="top: <?= $laneTop ?>px; left: <?= round($startPct, 4) ?>%; width: max(var(--timeline-block-min-width), <?= round($timelineWidthPct, 4) ?>%); max-width: calc(100% - <?= round($startPct, 4) ?>%); --agent-accent: <?= bbs_agent_color((int) $b['agent_id']) ?>; --past-pct: <?= round($timelinePastPct, 2) ?>%;<?= $timelineMinWidth !== null ? ' --timeline-block-min-width: ' . $timelineMinWidth . ';' : '' ?>">
                         </div>
                     <?php endforeach; ?>
                     <?php if (empty($blocksByDay[$dIdx])): ?>
@@ -1268,7 +1292,7 @@ document.addEventListener('DOMContentLoaded', function () {
             'Est. duration: <strong>' + esc(el.dataset.duration || '') + '</strong>' +
             (el.dataset.jobStatus === 'failed' ? '<br>Result: <strong>Error</strong>' : '') +
             (el.dataset.estimated === '1' ? ' <span style="opacity:.6">(no history — default)</span>' : '') +
-            '<div class="tt-hint">' + (isMobileScheduleMode() && el.classList.contains('day-block') ? 'Long press for options' : 'Click for options') + '</div>';
+            '<div class="tt-hint">' + (isMobileScheduleMode() && (el.classList.contains('day-block') || el.classList.contains('hist-seg')) ? 'Long press for options' : 'Click for options') + '</div>';
     }
     function showSchedulePopup(el, ev) {
         showTimelineTooltip(scheduleTooltipHtml(el), ev);
@@ -1294,6 +1318,20 @@ document.addEventListener('DOMContentLoaded', function () {
     function suppressNextDayBlockTap() {
         suppressNextDayBlockClick = true;
         window.setTimeout(() => { suppressNextDayBlockClick = false; }, 1200);
+    }
+    const histSegLongPressMs = 560;
+    let histSegLongPressTimer = null;
+    let suppressNextHistSegClick = false;
+    let histSegPressPoint = null;
+    function clearHistSegLongPress() {
+        if (histSegLongPressTimer) {
+            window.clearTimeout(histSegLongPressTimer);
+            histSegLongPressTimer = null;
+        }
+    }
+    function suppressNextHistSegTap() {
+        suppressNextHistSegClick = true;
+        window.setTimeout(() => { suppressNextHistSegClick = false; }, 1200);
     }
 
     // Day-block hover tooltip
@@ -1340,13 +1378,52 @@ document.addEventListener('DOMContentLoaded', function () {
     // (same actions as the day-block click).
     document.querySelectorAll('.hist-seg').forEach(seg => {
         seg.addEventListener('mouseenter', ev => {
+            if (isMobileScheduleMode()) return;
             showSchedulePopup(seg, ev);
         });
         seg.addEventListener('mousemove', moveTooltip);
         seg.addEventListener('mouseleave', hideTooltip);
+        seg.addEventListener('pointerdown', ev => {
+            if (!isMobileScheduleMode() || ev.pointerType === 'mouse') return;
+            clearHistSegLongPress();
+            suppressNextHistSegClick = false;
+            histSegPressPoint = { clientX: ev.clientX, clientY: ev.clientY };
+            histSegLongPressTimer = window.setTimeout(() => {
+                histSegLongPressTimer = null;
+                suppressNextHistSegTap();
+                openScheduleContext(seg, histSegPressPoint);
+            }, histSegLongPressMs);
+        });
+        seg.addEventListener('pointermove', ev => {
+            if (!histSegLongPressTimer || !histSegPressPoint) return;
+            const dx = ev.clientX - histSegPressPoint.clientX;
+            const dy = ev.clientY - histSegPressPoint.clientY;
+            if (Math.hypot(dx, dy) > 10) clearHistSegLongPress();
+        });
+        seg.addEventListener('pointerup', clearHistSegLongPress);
+        seg.addEventListener('pointercancel', clearHistSegLongPress);
+        seg.addEventListener('pointerleave', clearHistSegLongPress);
+        seg.addEventListener('contextmenu', ev => {
+            if (!isMobileScheduleMode()) return;
+            ev.preventDefault();
+            suppressNextHistSegTap();
+            const point = (ev.clientX || ev.clientY)
+                ? { clientX: ev.clientX, clientY: ev.clientY }
+                : (histSegPressPoint || { clientX: window.innerWidth / 2, clientY: window.innerHeight / 2 });
+            openScheduleContext(seg, point);
+        });
         seg.addEventListener('click', ev => {
             ev.preventDefault();
             ev.stopPropagation();
+            if (isMobileScheduleMode()) {
+                if (suppressNextHistSegClick) {
+                    suppressNextHistSegClick = false;
+                    return;
+                }
+                closeCtxMenu();
+                showSchedulePopup(seg, ev);
+                return;
+            }
             openScheduleContext(seg, ev);
         });
     });

--- a/src/Views/schedules/week.php
+++ b/src/Views/schedules/week.php
@@ -116,6 +116,17 @@ function bbs_histogram_ticks(int $max): array
     --schedule-concrete-bg-2: #9da6b2;
     --schedule-concrete-ink: #1f2933;
     --schedule-concrete-line: rgba(43, 50, 60, 0.14);
+    --schedule-error-bg: #cf5b5f;
+    --schedule-error-bg-2: #8f2732;
+    --schedule-error-hot: #ff777d;
+    --schedule-error-ink: #fff3f4;
+    --schedule-error-crack: rgba(70, 6, 14, 0.5);
+    --schedule-error-cracked:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.16), rgba(65, 4, 12, 0.34)),
+        linear-gradient(28deg, transparent 0 36%, var(--schedule-error-crack) 36% 37.5%, transparent 37.5% 100%),
+        linear-gradient(148deg, transparent 0 62%, rgba(255, 210, 214, 0.32) 62% 63%, transparent 63% 100%),
+        repeating-linear-gradient(112deg, transparent 0 16px, rgba(78, 0, 12, 0.28) 16px 17px, transparent 17px 31px),
+        linear-gradient(135deg, var(--schedule-error-bg), var(--schedule-error-bg-2));
 }
 [data-bs-theme="dark"] {
     --schedule-laser: #36a2ff;
@@ -130,6 +141,11 @@ function bbs_histogram_ticks(int $max): array
     --schedule-concrete-bg-2: #333b45;
     --schedule-concrete-ink: #f1f5f9;
     --schedule-concrete-line: rgba(255, 255, 255, 0.08);
+    --schedule-error-bg: #9f2f39;
+    --schedule-error-bg-2: #451018;
+    --schedule-error-hot: #ff5c66;
+    --schedule-error-ink: #fff5f6;
+    --schedule-error-crack: rgba(12, 0, 3, 0.68);
 }
 .schedule-shell {
     color-scheme: light dark;
@@ -179,7 +195,7 @@ function bbs_histogram_ticks(int $max): array
 .hist-current-time-line::before {
     content: "";
     position: absolute;
-    left: -5px;
+    left: -6px;
     top: -5px;
     width: 10px;
     height: 10px;
@@ -192,7 +208,7 @@ function bbs_histogram_ticks(int $max): array
 }
 .hist-current-time-line .current-time-label {
     position: absolute;
-    top: 2px;
+    top: -20px;
     left: 8px;
     padding: 2px 8px;
     border-radius: 999px;
@@ -300,12 +316,24 @@ function bbs_histogram_ticks(int $max): array
 .hist-event.is-past {
     color: var(--schedule-concrete-ink);
     text-shadow: none;
+    z-index: inherit;
+}
+.hist-event.is-error::after {
+    background: var(--schedule-error-cracked);
+    box-shadow: inset 0 0 14px rgba(54, 0, 8, 0.28);
+}
+.hist-event.is-error.is-past {
+    color: var(--schedule-error-ink);
 }
 .hist-seg.is-past {
     background:
         repeating-linear-gradient(45deg, var(--schedule-concrete-line) 0 1px, transparent 1px 6px),
         linear-gradient(180deg, var(--schedule-concrete-bg), var(--schedule-concrete-bg-2));
-    border-left: 2px solid var(--agent-accent);
+    border-left: 5px solid var(--agent-accent);
+}
+.hist-seg.is-error.is-past {
+    background: var(--schedule-error-cracked);
+    border-left-color: var(--schedule-error-hot);
 }
 .hist-seg:hover {
     filter: brightness(1.25);
@@ -474,7 +502,7 @@ function bbs_histogram_ticks(int $max): array
 .current-time-line .current-time-label {
     position: absolute;
     right: 8px;
-    top: -13px;
+    top: -8px;
     padding: 2px 8px;
     border-radius: 999px;
     background: linear-gradient(135deg, var(--schedule-laser), #243a6b);
@@ -505,7 +533,7 @@ function bbs_histogram_ticks(int $max): array
     color: #fff;
     overflow: hidden;
     cursor: pointer;
-    border-left: 4px solid var(--agent-accent);
+    border-left: 5px solid var(--agent-accent);
     transition: opacity 0.15s, transform 0.15s, filter 0.15s;
     text-decoration: none;
     background:
@@ -576,10 +604,20 @@ function bbs_histogram_ticks(int $max): array
 .day-block.is-active {
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.78), 0 0 5px rgba(0, 0, 0, 0.42);
 }
+.day-block.is-error::after {
+    background: var(--schedule-error-cracked);
+    box-shadow: inset 0 -10px 22px rgba(54, 0, 8, 0.25);
+}
+.day-block.is-error.is-past {
+    color: var(--schedule-error-ink);
+}
 .day-block.is-past::before {
     background: var(--agent-accent);
     box-shadow: none;
     opacity: 0.9;
+}
+.day-block.is-error.is-past::before {
+    background: var(--schedule-error-hot);
 }
 .day-block.estimated {
     background-image:
@@ -862,11 +900,12 @@ function bbs_histogram_ticks(int $max): array
                         $laneTop = (int) ($b['lane'] ?? 0) * 30;
                         $timelinePastPct = bbs_schedule_progress_pct((int) $b['day_idx'], (int) $b['start_min'], (int) $b['duration_min'], $todayIdx, $currentMinuteOfDay);
                         $timelinePhase = bbs_day_block_phase($timelinePastPct);
+                        $timelineIsError = !empty($b['has_error']);
                         $timelineDurLabel = $b['duration_min'] >= 60
                             ? floor($b['duration_min'] / 60) . 'h ' . ($b['duration_min'] % 60) . 'm'
                             : $b['duration_min'] . 'm';
                         ?>
-                        <div class="hist-seg hist-event is-<?= $timelinePhase ?>"
+                        <div class="hist-seg hist-event is-<?= $timelinePhase ?> <?= $timelineIsError ? 'is-error' : '' ?>"
                              data-schedule-id="<?= $b['schedule_id'] ?>"
                              data-agent-id="<?= (int) $b['agent_id'] ?>"
                              data-plan-name="<?= htmlspecialchars($b['plan_name']) ?>"
@@ -874,6 +913,7 @@ function bbs_histogram_ticks(int $max): array
                              data-time="<?= htmlspecialchars($b['time_label']) ?>"
                              data-duration="<?= htmlspecialchars($timelineDurLabel) ?>"
                              data-frequency="<?= htmlspecialchars($b['frequency']) ?>"
+                             data-job-status="<?= htmlspecialchars($b['job_status'] ?? '') ?>"
                              style="top: <?= $laneTop ?>px; left: <?= round($startPct, 4) ?>%; width: max(var(--timeline-block-min-width, 46px), <?= round($durationPct, 4) ?>%); max-width: calc(100% - <?= round($startPct, 4) ?>%); --agent-accent: <?= bbs_agent_color((int) $b['agent_id']) ?>; --past-pct: <?= round($timelinePastPct, 2) ?>%;">
                         </div>
                     <?php endforeach; ?>
@@ -957,6 +997,7 @@ function bbs_histogram_ticks(int $max): array
                             $color = bbs_agent_color($b['agent_id']);
                             $pastPct = bbs_day_block_progress_pct((int) $b['day_idx'], (int) $b['start_min'], (float) $height, $todayIdx, $currentMinuteOfDay, $pxPerHour);
                             $phase = bbs_day_block_phase($pastPct);
+                            $isError = !empty($b['has_error']);
                             $durLabel = $b['duration_min'] >= 60
                                 ? floor($b['duration_min'] / 60) . 'h ' . ($b['duration_min'] % 60) . 'm'
                                 : $b['duration_min'] . 'm';
@@ -970,7 +1011,7 @@ function bbs_histogram_ticks(int $max): array
                                 $b['estimated'] ? ' (no history)' : ''
                             );
                             ?>
-                        <div class="day-block <?= $b['estimated'] ? 'estimated' : '' ?> is-<?= $phase ?>"
+                        <div class="day-block <?= $b['estimated'] ? 'estimated' : '' ?> is-<?= $phase ?> <?= $isError ? 'is-error' : '' ?>"
                              data-agent-id="<?= $b['agent_id'] ?>"
                              data-schedule-id="<?= $b['schedule_id'] ?>"
                              data-plan-id="<?= $b['plan_id'] ?>"
@@ -980,6 +1021,7 @@ function bbs_histogram_ticks(int $max): array
                              data-time="<?= htmlspecialchars($b['time_label']) ?>"
                              data-duration="<?= htmlspecialchars($durLabel) ?>"
                              data-estimated="<?= $b['estimated'] ? '1' : '0' ?>"
+                             data-job-status="<?= htmlspecialchars($b['job_status'] ?? '') ?>"
                              style="top: <?= $top ?>px; height: <?= $height ?>px; left: calc(<?= $left ?>% + 4px); width: calc(<?= $laneWidth ?>% - 8px); --agent-accent: <?= $color ?>; --past-pct: <?= round($pastPct, 2) ?>%;">
                             <div class="agent"><?= htmlspecialchars($b['agent_name']) ?></div>
                             <div class="side">
@@ -1195,6 +1237,7 @@ document.addEventListener('DOMContentLoaded', function () {
             '<div class="tt-meta">' + esc(el.dataset.frequency) + '</div>' +
             'Starts: <strong>' + esc(el.dataset.time) + '</strong><br>' +
             'Est. duration: <strong>' + esc(el.dataset.duration || '') + '</strong>' +
+            (el.dataset.jobStatus === 'failed' ? '<br>Result: <strong>Error</strong>' : '') +
             (el.dataset.estimated === '1' ? ' <span style="opacity:.6">(no history — default)</span>' : '') +
             '<div class="tt-hint">' + (isMobileScheduleMode() && el.classList.contains('day-block') ? 'Long press for options' : 'Click for options') + '</div>';
     }


### PR DESCRIPTION
## Changes

- Added visual error state support for completed backup schedule blocks.
- Failed backup blocks now render with a red cracked texture instead of the gray concrete texture. (If you will make a re-run and job has been successfully finished, block become to the normal concrete structure)  
- Applied the error styling to both schedule views:
  - top horizontal backup timeline
  - lower vertical day timeline
- Added latest terminal backup job lookup per plan in `ScheduleController`.
- Kept duration estimates based only on successful backup jobs.
- Added `Result: Error` to schedule block tooltips for failed backups.
- Tuned schedule timeline CSS offsets and borders.
- Updated `--bs-box-shadow-sm` in the served root CSS variables.
- Improved dashboard health progress label text shadow.

<img width="2410" height="871" alt="Screenshot from 2026-05-06 14-41-55" src="https://github.com/user-attachments/assets/d1f67185-d8f7-423d-8268-280e08f7af45" />
<img width="2410" height="871" alt="Screenshot from 2026-05-06 14-42-13" src="https://github.com/user-attachments/assets/b50331d7-90aa-42dd-ba4a-4eae5a33cc89" />


## Validation

- `php -l src/Controllers/ScheduleController.php`
- `php -l src/Views/schedules/week.php`
- `php -l src/Views/dashboard/index.php`
- `git diff --check`

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal
