### PR TITLE
Add admin summary API endpoint

### DIFF
--- a/src/Controllers/Api/AdminApiController.php
+++ b/src/Controllers/Api/AdminApiController.php
@@ -34,6 +34,71 @@ class AdminApiController extends Controller
         $this->json(['clients' => $agents]);
     }
 
+    public function summary(): void
+    {
+        $this->requireApiToken();
+
+        $rows = $this->db->fetchAll("
+            SELECT
+                a.id AS client_id,
+                a.name AS client_name,
+                a.status AS client_status,
+                bp.id AS backup_plan_id,
+                bp.name AS backup_plan_name,
+                bj.id AS last_backup_job_id,
+                bj.status AS last_backup_result,
+                bj.duration_seconds AS last_backup_duration_seconds,
+                bj.queued_at AS last_backup_queued_at,
+                bj.started_at AS last_backup_started_at,
+                bj.completed_at AS last_backup_completed_at
+            FROM agents a
+            LEFT JOIN backup_plans bp ON bp.agent_id = a.id
+            LEFT JOIN backup_jobs bj ON bj.id = (
+                SELECT bj2.id
+                FROM backup_jobs bj2
+                WHERE bj2.backup_plan_id = bp.id
+                  AND bj2.task_type = 'backup'
+                ORDER BY COALESCE(bj2.completed_at, bj2.started_at, bj2.queued_at) DESC, bj2.id DESC
+                LIMIT 1
+            )
+            ORDER BY a.name, bp.name
+        ");
+
+        $clients = [];
+        foreach ($rows as $row) {
+            $clientId = (int) $row['client_id'];
+            if (!isset($clients[$clientId])) {
+                $clients[$clientId] = [
+                    'id' => $clientId,
+                    'name' => $row['client_name'],
+                    'status' => $row['client_status'],
+                    'backup_plans' => [],
+                ];
+            }
+
+            if ($row['backup_plan_id'] === null) {
+                continue;
+            }
+
+            $clients[$clientId]['backup_plans'][] = [
+                'id' => (int) $row['backup_plan_id'],
+                'name' => $row['backup_plan_name'],
+                'last_backup' => $row['last_backup_job_id'] === null ? null : [
+                    'job_id' => (int) $row['last_backup_job_id'],
+                    'result' => $row['last_backup_result'],
+                    'duration_seconds' => $row['last_backup_duration_seconds'] !== null ? (int) $row['last_backup_duration_seconds'] : null,
+                    'queued_at' => $row['last_backup_queued_at'],
+                    'started_at' => $row['last_backup_started_at'],
+                    'completed_at' => $row['last_backup_completed_at'],
+                ],
+            ];
+        }
+
+        $this->json([
+            'clients' => array_values($clients),
+        ]);
+    }
+
     public function getClient(int $id): void
     {
         $this->requireApiToken();

--- a/src/Core/App.php
+++ b/src/Core/App.php
@@ -263,6 +263,7 @@ class App
         $this->router->map('GET', '/get-agent-windows', 'Api\\AgentApiController@getAgentWindows');
 
         // Admin API (token-authenticated)
+        $this->router->map('GET', '/api/v1/summary', 'Api\\AdminApiController@summary');
         $this->router->map('GET', '/api/v1/clients', 'Api\\AdminApiController@listClients');
         $this->router->map('POST', '/api/v1/clients', 'Api\\AdminApiController@createClient');
         $this->router->map('GET', '/api/v1/clients/[i:id]', 'Api\\AdminApiController@getClient');

--- a/src/Views/settings/index.php
+++ b/src/Views/settings/index.php
@@ -1832,6 +1832,7 @@ document.getElementById('appIconFileInput').addEventListener('change', function(
                 <tr><th>Method</th><th>Endpoint</th><th>Description</th></tr>
             </thead>
             <tbody>
+                <tr><td><span class="badge bg-success">GET</span></td><td><code>/api/v1/summary</code></td><td>Summary of each client's backup plans and latest backup result</td></tr>
                 <tr><td><span class="badge bg-success">GET</span></td><td><code>/api/v1/clients</code></td><td>List all clients</td></tr>
                 <tr><td><span class="badge bg-primary">POST</span></td><td><code>/api/v1/clients</code></td><td>Create a client (returns api_key for agent install)</td></tr>
                 <tr><td><span class="badge bg-success">GET</span></td><td><code>/api/v1/clients/{id}</code></td><td>Get client details with repos &amp; plans</td></tr>
@@ -1870,6 +1871,12 @@ document.getElementById('appIconFileInput').addEventListener('change', function(
   -H "Authorization: Bearer bbs_tok_..." \
   -H "Content-Type: application/json" \
   -d '{"name": "web-server-01"}'</code></pre>
+        </div>
+
+        <div class="mt-3">
+            <p class="small text-muted mb-1"><strong>Example: Backup summary</strong></p>
+            <pre class="bg-body-secondary p-2 rounded small mb-0"><code>curl https://your-server/api/v1/summary \
+  -H "Authorization: Bearer bbs_tok_..."</code></pre>
         </div>
 
         <div class="mt-3">


### PR DESCRIPTION
# Summary

Adds a new token-authenticated admin API method, `GET /api/v1/summary`, that returns each client with its backup plans and the latest backup job result for each plan.

This gives bots and other automation a much easier way to fetch a compact summary of the current system state without stitching together client, plan, and job history calls manually.

## Changes

- Registers `GET /api/v1/summary` in the admin API routes.
- Adds `AdminApiController::summary()` to return clients, backup plan names, latest backup result, duration, and job timestamps.
- Documents the new method and a curl example in `/settings?tab=api`.

## Example:

```
user@workstation ~> curl -X GET https://bbs.yourserver.net/api/v1/summary \
                     -H "Authorization: Bearer bbs_tok_***" | jq
{
  "clients": [
    {
      "id": 5,
      "name": "Agent 1",
      "status": "online",
      "backup_plans": [
        {
          "id": 6,
          "name": "Daily backup to local",
          "last_backup": {
            "job_id": 256,
            "result": "failed",
            "duration_seconds": 3,
            "queued_at": "2026-05-05 21:00:01",
            "started_at": "2026-05-05 21:00:19",
            "completed_at": "2026-05-05 21:00:22"
          }
        }
      ]
    },
    {
      "id": 1,
      "name": "Agent 2",
      "status": "online",
      "backup_plans": [
        {
          "id": 1,
          "name": "Daily backup to remote",
          "last_backup": {
            "job_id": 259,
            "result": "failed",
            "duration_seconds": 839,
            "queued_at": "2026-05-05 22:00:01",
            "started_at": "2026-05-05 22:00:16",
            "completed_at": "2026-05-05 22:14:15"
          }
        },
        {
          "id": 5,
          "name": "Daily backup to local",
          "last_backup": {
            "job_id": 260,
            "result": "completed",
            "duration_seconds": 3597,
            "queued_at": "2026-05-05 22:00:01",
            "started_at": "2026-05-05 22:14:16",
            "completed_at": "2026-05-05 23:14:13"
          }
        }
      ]
    },
  ]
}
```



## Validation

- `php -l src/Core/App.php`
- `php -l src/Controllers/Api/AdminApiController.php`
- `php -l src/Views/settings/index.php`

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal
