### PR TITLE
Chain du-sk → borg info → SUM for remote SSH repo size (#245, #258)

### DIFF
--- a/scheduler.php
+++ b/scheduler.php
@@ -1602,8 +1602,8 @@ foreach ($serverJobs as $sj) {
                 ]);
             }
             // Refresh archive count + size. Prune just shrank the repo,
-            // so measure actual disk usage now (local) or re-sum archives
-            // (remote SSH) — see RepositorySizeService.
+            // so measure actual disk usage now — see RepositorySizeService
+            // for the local/remote chain.
             $db->query(
                 "UPDATE repositories SET archive_count = (SELECT COUNT(*) FROM archives WHERE repository_id = ?) WHERE id = ?",
                 [$repoId, $repoId]

--- a/src/Controllers/Api/AgentApiController.php
+++ b/src/Controllers/Api/AgentApiController.php
@@ -427,9 +427,9 @@ class AgentApiController extends Controller
             ]);
 
             // Update archive count + borg version. Size is refreshed below
-            // via RepositorySizeService (du for local, SUM for remote SSH) —
-            // runs once per backup instead of a periodic scan, so idle disks
-            // stay idle.
+            // via RepositorySizeService (du locally; du-then-borg-info over
+            // SSH) — runs once per backup instead of a periodic scan, so
+            // idle disks stay idle.
             $borgVer = !empty($agent['borg_version']) ? preg_replace('/^borg\s+/', '', $agent['borg_version']) : null;
             $this->db->query("
                 UPDATE repositories SET

--- a/src/Services/RemoteSshService.php
+++ b/src/Services/RemoteSshService.php
@@ -326,6 +326,91 @@ class RemoteSshService
     }
 
     /**
+     * Measure a single remote borg repository directory with `du -sk`.
+     * Returns bytes used on disk, or null if the path cannot be measured
+     * (e.g. BorgBase's borg-only shell rejects shell commands).
+     */
+    public function getRepositorySizeBytes(array $config, string $repoPath): ?int
+    {
+        $remotePath = $this->remoteFilesystemPathFromRepoUrl($repoPath);
+        if ($remotePath === null || $remotePath === '' || str_contains($remotePath, "\0")) {
+            return null;
+        }
+
+        $keyFile = null;
+        try {
+            $sshKey = $this->decryptKey($config);
+            $keyFile = $this->writeTempKey($sshKey);
+
+            $port = (int) ($config['remote_port'] ?? 22);
+            $sshCmd = [
+                'ssh',
+                '-i', $keyFile,
+                '-p', (string) $port,
+                '-o', 'StrictHostKeyChecking=no',
+                '-o', 'UserKnownHostsFile=/dev/null',
+                '-o', 'BatchMode=yes',
+                '-o', 'LogLevel=ERROR',
+                '-o', 'ConnectTimeout=30',
+                "{$config['remote_user']}@{$config['remote_host']}",
+                'du -sk -- ' . escapeshellarg($remotePath),
+            ];
+
+            $proc = proc_open($sshCmd, [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ], $pipes, null, $this->buildServerEnv());
+
+            if (!is_resource($proc)) {
+                return null;
+            }
+
+            fclose($pipes[0]);
+            $stdout = trim(stream_get_contents($pipes[1]));
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $exitCode = proc_close($proc);
+
+            if ($exitCode !== 0 || $stdout === '') {
+                return null;
+            }
+
+            $fields = preg_split('/\s+/', $stdout);
+            $kib = isset($fields[0]) && is_numeric($fields[0]) ? (int) $fields[0] : 0;
+            return $kib > 0 ? $kib * 1024 : 0;
+        } catch (\Throwable $e) {
+            return null;
+        } finally {
+            $this->cleanupTempKey($keyFile);
+        }
+    }
+
+    /**
+     * Convert a borg SSH URL to the remote filesystem path that `du` should
+     * measure. Borg conventions: ssh://user@host/relative → relative to home,
+     * ssh://user@host//absolute → absolute.
+     */
+    private function remoteFilesystemPathFromRepoUrl(string $repoPath): ?string
+    {
+        if (!str_starts_with($repoPath, 'ssh://')) {
+            return $repoPath;
+        }
+
+        $path = parse_url($repoPath, PHP_URL_PATH);
+        if (!is_string($path) || $path === '') {
+            return null;
+        }
+
+        $path = rawurldecode($path);
+        if (str_starts_with($path, '//')) {
+            return '/' . ltrim($path, '/');
+        }
+
+        return ltrim($path, '/');
+    }
+
+    /**
      * Decrypt the SSH private key from a config record.
      */
     private function decryptKey(array $config): string

--- a/src/Services/RepositorySizeService.php
+++ b/src/Services/RepositorySizeService.php
@@ -9,9 +9,15 @@ use BBS\Core\Database;
  * size: backup completion, prune, compact, and archive_delete.
  *
  * Local repos: `du` via bbs-ssh-helper.
- * Remote SSH repos: `borg info --json <repo>` and read cache.stats.unique_csize
- * (the deduplicated/compressed on-disk size); falls back to
- * SUM(archives.deduplicated_size) if borg info can't be reached.
+ *
+ * Remote SSH repos use a three-step chain so every provider gets the best
+ * answer it supports:
+ *   1. `du -sk` over SSH — most authoritative (matches what providers like
+ *      rsync.net and Hetzner actually bill for, including segment files,
+ *      indexes, FS allocation overhead, and uncompacted data).
+ *   2. `borg info --json` and read cache.stats.unique_csize — works on
+ *      borg-only shells like BorgBase where du is rejected.
+ *   3. SUM(archives.deduplicated_size) — last resort if both SSH paths fail.
  *
  * Previously a scheduler loop ran `du` on every local repo every 5 minutes,
  * which kept spinning disks awake on idle home servers. Now disks are only
@@ -26,15 +32,31 @@ class RepositorySizeService
         if (!$repo) return;
 
         if (($repo['storage_type'] ?? 'local') === 'remote_ssh') {
+            // Step 1: du -sk over SSH. Works on every backend with a real
+            // shell (rsync.net, Hetzner, generic Linux droplets, self-hosted).
+            $configId = (int) ($repo['remote_ssh_config_id'] ?? 0);
+            $config = $configId > 0
+                ? $db->fetchOne("SELECT * FROM remote_ssh_configs WHERE id = ?", [$configId])
+                : null;
+            if ($config) {
+                $duBytes = (new RemoteSshService())->getRepositorySizeBytes($config, $repo['path']);
+                if ($duBytes !== null) {
+                    $db->update('repositories', ['size_bytes' => $duBytes], 'id = ?', [$repoId]);
+                    return;
+                }
+            }
+
+            // Step 2: borg info — for borg-only shells (BorgBase) where
+            // du is rejected.
             $unique = self::fetchRepoUniqueCsize($repo);
             if ($unique !== null) {
                 $db->update('repositories', ['size_bytes' => $unique], 'id = ?', [$repoId]);
                 return;
             }
-            // Fall back to SUM of per-archive deduplicated_size when borg info
-            // can't be reached. Known to under-report (it's a sum of the
-            // *incremental* contributions of each archive at the time it was
-            // created), but it's better than a stale value.
+
+            // Step 3: SUM of per-archive deduplicated_size. Known to
+            // under-report (it's the *incremental* contribution at archive
+            // creation, not current state), but it's better than nothing.
             $db->query(
                 "UPDATE repositories SET size_bytes = COALESCE(
                     (SELECT SUM(deduplicated_size) FROM archives WHERE repository_id = ?), 0


### PR DESCRIPTION
## Summary

Builds on @c0dr1ver's PR #245 by chaining the `du -sk` measurement ahead of the `borg info` path that already shipped in v2.52.2 for #258. Net effect: every remote SSH backend now gets the most accurate number it supports.

## The chain

`RepositorySizeService::refresh()` for `storage_type='remote_ssh'`:

1. **`du -sk` over SSH** — for any provider with a real shell (rsync.net, Hetzner Storage Box, DigitalOcean droplets, generic Linux, self-hosted). This is what providers actually bill for, and it captures segment files, indexes, FS allocation overhead, and uncompacted data that borg's deduplicated_size doesn't.
2. **`borg info --json` → `cache.stats.unique_csize`** — for borg-only shells like BorgBase that reject shell commands.
3. **`SUM(archives.deduplicated_size)`** — last resort if both SSH paths fail.

`du`-only loses BorgBase. `borg-info`-only loses the bigger, more accurate number on shell-capable providers (#245's screenshots showed a 7× difference: 98 GB SUM vs 684 GB du on a single repo). Chaining is a strict superset.

## Provenance

- `RemoteSshService::getRepositorySizeBytes()` and `remoteFilesystemPathFromRepoUrl()` are taken verbatim from #245.
- The `borg info` step and `RepositorySizeService::fetchRepoUniqueCsize()` were added in #258 / v2.52.2.
- The chain ordering and comment updates are in this PR.

Crediting @c0dr1ver via `Co-authored-by` on the commit. PR #245 should be closed in favour of this one.

## Coverage by backend

| Backend | Step that succeeds |
|---|---|
| rsync.net | du |
| Hetzner Storage Box | du |
| DigitalOcean / generic Linux SSH | du |
| Self-hosted | du |
| BorgBase (borg-only shell) | borg info |
| Anything else / SSH down | SUM (last resort) |

## Validation

- `php -l` clean on all changed files
- Test on a server with all three remote backend types (rsync.net, Hetzner, BorgBase) — each should land on its expected step

## Testing

- [ ] Tested on bare metal with all three remote SSH backend types
- [ ] Tested on Docker