### PR TITLE
Fix upgrade summary scrolling on small screens

### DIFF
--- a/src/Views/upgrade/index.php
+++ b/src/Views/upgrade/index.php
@@ -89,11 +89,52 @@ $stepIcon = function(string $status): string {
 };
 ?>
 
+<style>
+/* The upgrade page lives in the auth layout without the art pane. On short
+   phone viewports the inherited framed layout can clip the long step summary,
+   so keep this page's frame allowed to grow and make the summary itself
+   scrollable. */
+body.auth-no-art .auth-frame {
+    overflow: visible;
+}
+
+#upgrade-steps {
+    max-height: min(520px, calc(100dvh - 260px));
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+#upgrade-step,
+.upgrade-step-title {
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 575.98px) {
+    body.auth-no-art .auth-form-pane {
+        padding: 16px 12px 16px;
+    }
+
+    #upgrade-steps {
+        max-height: calc(100dvh - 230px);
+    }
+
+    .upgrade-card .card-header,
+    .upgrade-card .card-body {
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    .upgrade-step-link {
+        align-items: flex-start !important;
+    }
+}
+</style>
+
 <!-- Cap width on wide displays so the step list and release-notes paragraphs
      don't stretch into one-line-of-2560px walls of text (#226). -->
 <div class="mx-auto" style="max-width: 1100px;">
 
-<div class="card border-0 shadow-sm mb-4">
+<div class="card border-0 shadow-sm mb-4 upgrade-card">
     <div class="card-header fw-semibold d-flex justify-content-between align-items-center">
         <span><i class="bi bi-cloud-arrow-down me-1"></i> System Upgrade</span>
         <?php if ($target): ?>
@@ -145,10 +186,10 @@ $stepIcon = function(string $status): string {
             <?php foreach ($steps as $i => $step): ?>
             <div class="border-bottom">
                 <?php $hasDetail = !empty(array_filter($step['lines'], fn($l) => trim($l) !== '')); ?>
-                <a class="d-flex align-items-center px-3 py-2 text-decoration-none text-body <?= $hasDetail ? '' : 'pe-none' ?>" data-bs-toggle="<?= $hasDetail ? 'collapse' : '' ?>" href="#step-detail-<?= $i ?>" role="button" aria-expanded="false">
+                <a class="d-flex align-items-center px-3 py-2 text-decoration-none text-body upgrade-step-link <?= $hasDetail ? '' : 'pe-none' ?>" data-bs-toggle="<?= $hasDetail ? 'collapse' : '' ?>" href="#step-detail-<?= $i ?>" role="button" aria-expanded="false">
                     <span class="me-2" style="width:20px;"><?= $stepIcon($step['status']) ?></span>
                     <span class="text-muted me-2 small" style="min-width:52px;">[<?= $step['num'] ?>/<?= $step['total'] ?>]</span>
-                    <span class="flex-grow-1"><?= htmlspecialchars($step['title']) ?></span>
+                    <span class="flex-grow-1 upgrade-step-title"><?= htmlspecialchars($step['title']) ?></span>
                     <?php if ($hasDetail): ?>
                     <i class="bi bi-chevron-down small text-muted"></i>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary

Fixes the `/upgrade` progress page on short mobile viewports where the upgrade step summary could be clipped after refresh and the hidden tasks were not reachable.

## Root Cause

The upgrade page renders inside the auth layout with the art pane hidden. On mobile, that layout still inherited frame clipping from `.auth-frame`, while the long upgrade step list did not have its own scroll area. On devices such as iPhone SE or iPhone 12 mini, the lower steps could fall outside the visible area with no practical way to scroll to them.

## Changes

- Allow the no-art auth frame used by `/upgrade` to grow instead of clipping content.
- Add a touch-friendly scroll area to `#upgrade-steps` using viewport-relative height.
- Tighten mobile spacing on the upgrade card and allow long step text to wrap cleanly.

## Impact

Users on small screens can now scroll the upgrade summary and inspect all tasks, including those below the initial viewport after the page refreshes during/after an upgrade.

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal
