### PR TITLE
Fix BorgBase API verification helper scope

### DIFF
--- a/src/Views/storage-locations/index.php
+++ b/src/Views/storage-locations/index.php
@@ -19,6 +19,14 @@ function formatStorageBytesDecimal(int $bytes): string {
 $section = $_GET['section'] ?? '';
 ?>
 
+<script>
+function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, function(ch) {
+        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[ch];
+    });
+}
+</script>
+
 <?php if ($section === 's3'): ?>
 <!-- ==================== S3 Sync Settings ==================== -->
 <nav class="mb-4">
@@ -593,12 +601,6 @@ scp ~/.ssh/rsyncnet.pub <span class="text-warning" id="rsnScpUser">USERNAME</spa
 </div>
 
 <script>
-function escapeHtml(value) {
-    return String(value).replace(/[&<>"']/g, function(ch) {
-        return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[ch];
-    });
-}
-
 function showWizardForm(provider) {
     document.getElementById('wizardProviders').style.display = 'none';
     document.getElementById('wizard' + provider.charAt(0).toUpperCase() + provider.slice(1)).style.display = 'block';
@@ -1488,11 +1490,6 @@ function testBorgbaseApiExisting(id) {
     var apiKey = apiInput ? apiInput.value.trim() : '';
     var repoName = repoInput ? repoInput.value.trim() : '';
     var hasSavedKey = apiInput && apiInput.dataset.hasSavedKey === '1';
-    var esc = function(value) {
-        return String(value).replace(/[&<>"']/g, function(ch) {
-            return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[ch];
-        });
-    };
 
     if (!apiKey && !hasSavedKey) {
         resultDiv.style.display = 'block';


### PR DESCRIPTION
## Summary

- Move `escapeHtml()` into an always-rendered script block in `storage-locations/index.php`.
- Remove the wizard-local duplicate helper.
- Remove the now-unused local `esc` helper from `testBorgbaseApiExisting()`.

## Root Cause

After the previous follow-up, `testBorgbaseApiExisting()` calls `escapeHtml(...)` when rendering Verify API results for existing BorgBase storage configs. However, `escapeHtml()` was defined only inside the wizard-only section, so it was available on `/storage-locations?section=wizard` but not on the normal `/storage-locations` page.

That made the API request succeed, but the UI render path threw `ReferenceError: escapeHtml is not defined`, leaving the edit modal stuck on “Checking BorgBase API...”.

## Validation

- `php -l src/Views/storage-locations/index.php`

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal