### PR TITLE
Centralize duration formatting

### DIFF
--- a/public/js/app-utils.js
+++ b/public/js/app-utils.js
@@ -1,0 +1,29 @@
+(function(window) {
+    const BBS = window.BBS = window.BBS || {};
+    const durationCache = new Map();
+
+    BBS.formatDuration = function(seconds) {
+        seconds = Math.max(0, parseInt(seconds, 10) || 0);
+        if (seconds <= 0) return '--';
+        if (durationCache.has(seconds)) return durationCache.get(seconds);
+
+        const days = Math.floor(seconds / 86400);
+        const hours = Math.floor((seconds % 86400) / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        const secs = seconds % 60;
+
+        let label;
+        if (days > 0) {
+            label = days + 'd ' + hours + 'h';
+        } else if (hours > 0) {
+            label = hours + 'h ' + minutes + 'm';
+        } else if (minutes > 0) {
+            label = minutes + 'm ' + secs + 's';
+        } else {
+            label = secs + 's';
+        }
+
+        durationCache.set(seconds, label);
+        return label;
+    };
+})(window);

--- a/src/Controllers/Api/AgentApiController.php
+++ b/src/Controllers/Api/AgentApiController.php
@@ -478,7 +478,7 @@ class AgentApiController extends Controller
         // Log the result
         $level = $result === 'completed' ? 'info' : 'error';
         $message = $result === 'completed'
-            ? "{$taskLabel} completed: job #{$jobId}" . (($data['files_total'] ?? 0) > 0 ? ", {$data['files_total']} files" : '') . ", " . $this->formatDuration($duration)
+            ? "{$taskLabel} completed: job #{$jobId}" . (($data['files_total'] ?? 0) > 0 ? ", {$data['files_total']} files" : '') . ", " . \BBS\Core\TimeHelper::duration($duration, '0s')
             : "{$taskLabel} failed: job #{$jobId} — " . ($input['error_log'] ?? 'unknown error');
 
         $this->db->insert('server_log', [
@@ -543,7 +543,7 @@ class AgentApiController extends Controller
                         $agent['id'],
                         (int)$job['backup_plan_id'],
                         "Backup completed for plan \"{$planName}\" on client \"{$agent['name']}\"" .
-                            (($data['files_total'] ?? 0) > 0 ? " — {$data['files_total']} files in " . $this->formatDuration($duration) : ''),
+                            (($data['files_total'] ?? 0) > 0 ? " — {$data['files_total']} files in " . \BBS\Core\TimeHelper::duration($duration, '0s') : ''),
                         'info'
                     );
                 }
@@ -1133,23 +1133,6 @@ class AgentApiController extends Controller
         $raw = file_get_contents('php://input');
         $data = json_decode($raw, true);
         return is_array($data) ? $data : [];
-    }
-
-    private function formatDuration(int $seconds): string
-    {
-        $d = intdiv($seconds, 86400);
-        $h = intdiv($seconds % 86400, 3600);
-        $m = intdiv($seconds % 3600, 60);
-        $s = $seconds % 60;
-
-        $parts = [];
-
-        if ($d > 0) $parts[] = "{$d}d";
-        if ($h > 0) $parts[] = "{$h}h";
-        if ($m > 0) $parts[] = "{$m}m";
-        if ($s > 0 || empty($parts)) $parts[] = "{$s}s";
-
-        return implode(' ', $parts);
     }
 
     private function formatBytesLog(int $bytes): string

--- a/src/Controllers/ClientController.php
+++ b/src/Controllers/ClientController.php
@@ -577,8 +577,7 @@ class ClientController extends Controller
         }
 
         // Format avg duration
-        $avgDuration = (int) ($jobStats['avg_duration'] ?? 0);
-        $avgDurLabel = $avgDuration >= 60 ? floor($avgDuration / 60) . 'm ' . ($avgDuration % 60) . 's' : $avgDuration . 's';
+        $avgDurLabel = \BBS\Core\TimeHelper::duration((int) ($jobStats['avg_duration'] ?? 0));
 
         // Format last backup
         $lastBackupLabel = $lastJob ? \BBS\Core\TimeHelper::format($lastJob['completed_at'], 'M j g:ia') : '--';

--- a/src/Core/TimeHelper.php
+++ b/src/Core/TimeHelper.php
@@ -4,6 +4,8 @@ namespace BBS\Core;
 
 class TimeHelper
 {
+    private static array $durationCache = [];
+
     /**
      * Format a UTC timestamp for display in the user's timezone.
      * Automatically converts 12h format tokens to 24h if the user prefers it.
@@ -54,6 +56,38 @@ class TimeHelper
             return floor($diff / 3600) . 'h ago';
         }
         return floor($diff / 86400) . 'd ago';
+    }
+
+    /**
+     * Return a compact duration label for elapsed seconds.
+     */
+    public static function duration(?int $seconds, string $zeroLabel = '--'): string
+    {
+        $seconds = max(0, (int) ($seconds ?? 0));
+        if ($seconds <= 0) {
+            return $zeroLabel;
+        }
+
+        if (isset(self::$durationCache[$seconds])) {
+            return self::$durationCache[$seconds];
+        }
+
+        $days = intdiv($seconds, 86400);
+        $hours = intdiv($seconds % 86400, 3600);
+        $minutes = intdiv($seconds % 3600, 60);
+        $secs = $seconds % 60;
+
+        if ($days > 0) {
+            $label = "{$days}d {$hours}h";
+        } elseif ($hours > 0) {
+            $label = "{$hours}h {$minutes}m";
+        } elseif ($minutes > 0) {
+            $label = "{$minutes}m {$secs}s";
+        } else {
+            $label = "{$secs}s";
+        }
+
+        return self::$durationCache[$seconds] = $label;
     }
 
     /**

--- a/src/Views/clients/detail.php
+++ b/src/Views/clients/detail.php
@@ -257,8 +257,7 @@ $sizeDisplay = $totalSize > 0 ? \BBS\Services\ServerStats::formatBytes((int) $to
 <?php if ($tab === 'status'): ?>
     <?php
     // Compute status metrics
-    $avgDuration = (int) ($jobStats['avg_duration'] ?? 0);
-    $avgDurLabel = $avgDuration >= 60 ? floor($avgDuration / 60) . 'm ' . ($avgDuration % 60) . 's' : $avgDuration . 's';
+    $avgDurLabel = \BBS\Core\TimeHelper::duration((int) ($jobStats['avg_duration'] ?? 0));
     $successRate = ($jobStats['total'] ?? 0) > 0
         ? round(($jobStats['completed'] / $jobStats['total']) * 100)
         : 0;
@@ -459,10 +458,7 @@ $sizeDisplay = $totalSize > 0 ? \BBS\Services\ServerStats::formatBytes((int) $to
                             'queued','sent' => 'hourglass-split text-warning',
                             default => 'dash-circle text-secondary',
                         };
-                        $d = (int) ($job['duration_seconds'] ?? 0);
-                        $durStr = $d >= 3600 ? floor($d / 3600) . 'h ' . floor(($d % 3600) / 60) . 'm'
-                            : ($d >= 60 ? floor($d / 60) . 'm ' . ($d % 60) . 's'
-                                : ($d > 0 ? $d . 's' : '--'));
+                        $durStr = \BBS\Core\TimeHelper::duration((int) ($job['duration_seconds'] ?? 0));
                         $when = $job['completed_at'] ?? $job['started_at'] ?? $job['queued_at'];
                         $iconTitle = '';
                         if ($job['status'] === 'failed' && !empty($job['error_log'])) {

--- a/src/Views/dashboard/index.php
+++ b/src/Views/dashboard/index.php
@@ -19,17 +19,6 @@ $fmtUptime = function (?int $s): string {
     if ($h > 0) return "{$h}h {$m}m";
     return "{$m}m";
 };
-$fmtDuration = function (?int $s): string {
-    if (!$s || $s <= 0) return '--';
-    $h = intdiv($s, 3600);
-    $s %= 3600;
-    $m = intdiv($s, 60);
-    $s %= 60;
-    if ($h > 0) return sprintf('%dh %02dm', $h, $m);
-    if ($m > 0) return sprintf('%dm %02ds', $m, $s);
-    return "{$s}s";
-};
-
 // Dedup savings % (original data vs actual disk footprint).
 // Clamp the displayed value at 99.9% when there's still bytes on disk —
 // round() lifts 99.95%+ to 100% which misrepresents a non-empty repo (#191).
@@ -599,7 +588,7 @@ $dfFix = function (string $s): string {
                             <td class="d-table-cell-md"><?= htmlspecialchars($j['plan_name'] ?? '--') ?></td>
                             <td class="d-table-cell-md"><?= htmlspecialchars($j['repo_name'] ?? '--') ?></td>
                             <td><?= TimeHelper::ago($j['completed_at']) ?></td>
-                            <td class="d-table-cell-md"><?= $fmtDuration((int) ($j['duration_seconds'] ?? 0)) ?></td>
+                            <td class="d-table-cell-md"><?= TimeHelper::duration((int) ($j['duration_seconds'] ?? 0)) ?></td>
                             <td class="text-center"><i class="bi <?= $statusIcon ?>"<?= $statusTitle ? ' data-bs-toggle="tooltip" title="' . htmlspecialchars($statusTitle) . '"' : '' ?>></i></td>
                         </tr>
                     <?php endforeach; ?>
@@ -1039,13 +1028,6 @@ document.addEventListener('DOMContentLoaded', function () {
             if (diff < 86400) return Math.floor(diff/3600) + 'h ago';
             return Math.floor(diff/86400) + 'd ago';
         }
-        function fmtDur(s) {
-            s = parseInt(s) || 0;
-            if (s >= 3600) return Math.floor(s/3600) + 'h ' + String(Math.floor((s%3600)/60)).padStart(2, '0') + 'm';
-            if (s >= 60) return Math.floor(s/60) + 'm ' + String(s%60).padStart(2, '0') + 's';
-            return s > 0 ? s + 's' : '--';
-        }
-
         // Task-type icon map (mirrors the PHP one above and queue/index.php)
         const TASK_ICONS = {
             'backup':          'bi-box-seam text-warning',
@@ -1086,7 +1068,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     + '<td class="d-table-cell-md">' + esc(j.plan_name || '--') + '</td>'
                     + '<td class="d-table-cell-md">' + esc(j.repo_name || '--') + '</td>'
                     + '<td>' + timeAgo(j.completed_at) + '</td>'
-                    + '<td class="d-table-cell-md">' + fmtDur(j.duration_seconds) + '</td>'
+                    + '<td class="d-table-cell-md">' + window.BBS.formatDuration(j.duration_seconds) + '</td>'
                     + '<td class="text-center"><i class="bi ' + icon + '"></i></td>'
                     + '</tr>';
             });

--- a/src/Views/dashboard/index.v1.bak.php
+++ b/src/Views/dashboard/index.v1.bak.php
@@ -455,8 +455,7 @@ $pieColors = ['#36a2eb', '#ff6384', '#ffce56', '#4bc0c0', '#9966ff', '#6c757d'];
                                 $elapsed = '';
                                 if ($job['started_at']) {
                                     $e = time() - strtotime($job['started_at'] . ' UTC');
-                                    $elapsed = $e >= 3600 ? floor($e / 3600) . 'h ' . floor(($e % 3600) / 60) . 'm'
-                                        : ($e >= 60 ? floor($e / 60) . 'm ' . ($e % 60) . 's' : $e . 's');
+                                    $elapsed = \BBS\Core\TimeHelper::duration($e);
                                 }
                             ?>
                             <tr style="cursor: pointer;" onclick="window.location='/queue/<?= $job['id'] ?>'">
@@ -591,9 +590,7 @@ $pieColors = ['#36a2eb', '#ff6384', '#ffce56', '#4bc0c0', '#9966ff', '#6c757d'];
                         <tbody class="small">
                             <?php foreach ($recentJobs as $job): ?>
                             <?php
-                                $d = $job['duration_seconds'] ?? 0;
-                                $durStr = $d >= 3600 ? floor($d / 3600) . 'h ' . floor(($d % 3600) / 60) . 'm'
-                                    : ($d >= 60 ? floor($d / 60) . 'm ' . ($d % 60) . 's' : ($d > 0 ? $d . 's' : '--'));
+                                $durStr = \BBS\Core\TimeHelper::duration((int) ($job['duration_seconds'] ?? 0));
                                 $sIcon = match($job['status']) {
                                     'completed' => '<i class="bi bi-check-circle-fill text-success"></i>',
                                     'failed' => '<i class="bi bi-x-circle-fill text-danger"></i>',
@@ -729,14 +726,6 @@ if (pieCanvas) {
 // Helper: escape HTML
 function esc(str) { const d = document.createElement('div'); d.textContent = str ?? ''; return d.innerHTML; }
 
-// Helper: format elapsed seconds
-function fmtDur(s) {
-    s = parseInt(s) || 0;
-    if (s >= 3600) return Math.floor(s/3600) + 'h ' + Math.floor((s%3600)/60) + 'm';
-    if (s >= 60) return Math.floor(s/60) + 'm ' + (s%60) + 's';
-    return s > 0 ? s + 's' : '--';
-}
-
 // Helper: format time diff for countdowns
 function fmtCountdown(diffSec) {
     if (diffSec < 0) return { text: 'Overdue', cls: 'text-danger fw-semibold' };
@@ -765,7 +754,7 @@ function renderActiveJobs(jobs) {
     let html = '<div class="table-responsive"><table class="table table-hover mb-0"><thead class="table-light"><tr><th>Client</th><th>Task</th><th class="d-th-md">Plan</th><th class="d-th-md">Repo</th><th>Progress</th><th class="d-th-md">Duration</th><th>Status</th></tr></thead><tbody class="small">';
     jobs.forEach(j => {
         let elapsed = '--';
-        if (j.started_at) { const e = now - Math.floor(new Date((j.started_at).replace(' ','T')+'Z').getTime()/1000); elapsed = fmtDur(e); }
+        if (j.started_at) { const e = now - Math.floor(new Date((j.started_at).replace(' ','T')+'Z').getTime()/1000); elapsed = window.BBS.formatDuration(e); }
         let progress = '';
         if (j.status === 'queued') { progress = '<span class="text-muted">Waiting</span>'; }
         else if ((j.files_total || 0) > 0) {
@@ -820,7 +809,7 @@ function renderRecentJobs(jobs) {
     if (!jobs || !jobs.length) { el.innerHTML = '<div class="p-4 text-muted text-center">No completed jobs yet</div>'; return; }
     let html = '<div class="table-responsive"><table class="table table-hover mb-0"><thead class="table-light"><tr><th>Client</th><th>Task</th><th class="d-th-md">Plan</th><th class="d-th-md">Repo</th><th>Completed</th><th class="d-th-md">Duration</th><th>Status</th></tr></thead><tbody class="small">';
     jobs.forEach(j => {
-        html += '<tr style="cursor:pointer" onclick="window.location=\'/queue/'+j.id+'\'"><td>'+esc(j.agent_name)+'</td><td>'+esc(j.task_type?.[0]?.toUpperCase()+j.task_type?.slice(1))+'</td><td class="d-table-cell-md">'+esc(j.plan_name||'--')+'</td><td class="d-table-cell-md">'+esc(j.repo_name||'--')+'</td><td title="'+esc(fmtDate(j.completed_at))+'">'+timeAgo(j.completed_at)+'</td><td class="d-table-cell-md text-nowrap">'+fmtDur(j.duration_seconds)+'</td><td class="text-center">'+statusIcon(j.status)+'</td></tr>';
+        html += '<tr style="cursor:pointer" onclick="window.location=\'/queue/'+j.id+'\'"><td>'+esc(j.agent_name)+'</td><td>'+esc(j.task_type?.[0]?.toUpperCase()+j.task_type?.slice(1))+'</td><td class="d-table-cell-md">'+esc(j.plan_name||'--')+'</td><td class="d-table-cell-md">'+esc(j.repo_name||'--')+'</td><td title="'+esc(fmtDate(j.completed_at))+'">'+timeAgo(j.completed_at)+'</td><td class="d-table-cell-md text-nowrap">'+window.BBS.formatDuration(j.duration_seconds)+'</td><td class="text-center">'+statusIcon(j.status)+'</td></tr>';
     });
     html += '</tbody></table></div>';
     el.innerHTML = html;

--- a/src/Views/layouts/app.php
+++ b/src/Views/layouts/app.php
@@ -8,6 +8,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link href="/css/style.css?v=<?= filemtime(__DIR__ . '/../../../public/css/style.css') ?>" rel="stylesheet">
+    <script src="/js/app-utils.js?v=<?= filemtime(__DIR__ . '/../../../public/js/app-utils.js') ?>"></script>
     <link rel="manifest" href="/manifest.json">
     <!-- Favicons + apple-touch-icon. Served by BrandingController, which
          resizes a single uploaded source (or the bundled mascot default)

--- a/src/Views/queue/detail.php
+++ b/src/Views/queue/detail.php
@@ -10,9 +10,7 @@ $statusLabel = ($job['status'] === 'completed' && !empty($job['had_warnings']))
     ? 'Completed with warnings'
     : ucfirst($job['status']);
 
-$d = $job['duration_seconds'] ?? 0;
-$durLabel = $d >= 3600 ? floor($d / 3600) . 'h ' . floor(($d % 3600) / 60) . 'm'
-    : ($d >= 60 ? floor($d / 60) . 'm ' . ($d % 60) . 's' : ($d > 0 ? $d . 's' : '--'));
+$durLabel = \BBS\Core\TimeHelper::duration((int) ($job['duration_seconds'] ?? 0));
 
 $pct = 0;
 if (($job['files_total'] ?? 0) > 0 && $job['files_processed'] > 0) {
@@ -589,13 +587,6 @@ $taskLabel = ucfirst(str_replace('_', ' ', $job['task_type']));
                dt.toLocaleTimeString('en-US', tOpts);
     }
 
-    function fmtDur(s) {
-        if (!s || s <= 0) return '--';
-        if (s >= 3600) return Math.floor(s/3600) + 'h ' + Math.floor((s%3600)/60) + 'm';
-        if (s >= 60) return Math.floor(s/60) + 'm ' + (s%60) + 's';
-        return s + 's';
-    }
-
     function fmtBytes(b) {
         if (!b || b == 0) return '--';
         const units = ['B','KB','MB','GB','TB'];
@@ -617,12 +608,12 @@ $taskLabel = ucfirst(str_replace('_', ' ', $job['task_type']));
                 container.innerHTML = '<div class="card border-0 shadow-sm mb-4 bg-success-subtle"><div class="card-body py-3">' +
                     '<div class="fw-semibold text-success mb-1"><i class="bi bi-hdd me-1"></i> ' + esc(job.task_type[0].toUpperCase()+job.task_type.slice(1)) + ' Completed</div>' +
                     '<div class="progress mb-1" style="height:22px"><div class="progress-bar bg-success" style="width:100%">Server-side ' + esc(job.task_type) + ' finished</div></div>' +
-                    '<div class="text-muted small">Duration: ' + fmtDur(job.duration_seconds) + ' &middot; See activity log below for details</div></div></div>';
+                    '<div class="text-muted small">Duration: ' + window.BBS.formatDuration(job.duration_seconds) + ' &middot; See activity log below for details</div></div></div>';
             } else {
                 container.innerHTML = '<div class="card border-0 shadow-sm mb-4 bg-success-subtle"><div class="card-body py-3">' +
                     '<div class="fw-semibold text-success mb-1">Completed</div>' +
                     '<div class="progress mb-1" style="height:22px"><div class="progress-bar bg-success" style="width:100%">' + (job.files_total ? Number(job.files_total).toLocaleString() + ' files processed' : 'Done') + '</div></div>' +
-                    '<div class="text-muted small">' + fmtBytes(job.bytes_total) + ' total &middot; ' + fmtDur(job.duration_seconds) + '</div></div></div>';
+                    '<div class="text-muted small">' + fmtBytes(job.bytes_total) + ' total &middot; ' + window.BBS.formatDuration(job.duration_seconds) + '</div></div></div>';
             }
         } else if (job.status === 'failed') {
             container.innerHTML = '<div class="card border-0 shadow-sm mb-4 bg-danger-subtle"><div class="card-body py-3">' +
@@ -694,7 +685,7 @@ $taskLabel = ucfirst(str_replace('_', ' ', $job['task_type']));
             }
             if (key === 'Started At' && job.started_at) td.nextElementSibling.textContent = fmtDate(job.started_at);
             if (key === 'Completed At' && job.completed_at) td.nextElementSibling.textContent = fmtDate(job.completed_at);
-            if (key === 'Duration') td.nextElementSibling.textContent = fmtDur(job.duration_seconds);
+            if (key === 'Duration') td.nextElementSibling.textContent = window.BBS.formatDuration(job.duration_seconds);
         });
     }
 

--- a/src/Views/queue/index.php
+++ b/src/Views/queue/index.php
@@ -1,14 +1,10 @@
 <?php
-    function formatDurationLabel(int $s): string {
-        return $s >= 3600 ? floor($s / 3600) . 'h ' . floor(($s % 3600) / 60) . 'm ' . ($s % 60) . 's' : ($s >= 60 ? floor($s / 60) . 'm ' . ($s % 60) . 's' : $s . 's');
-    }
-
-    $avgDur = $avgSec > 0 ? formatDurationLabel((int) $avgSec) : '--';
+    $avgDur = $avgSec > 0 ? \BBS\Core\TimeHelper::duration((int) $avgSec) : '--';
     $maxCompletedDuration = max(array_map(fn($j) => (int) ($j['duration_seconds'] ?? 0), $completed ?: [['duration_seconds' => 0]]));
 
     function durationBarHtml(int $duration, int $maxDuration, string $status = ''): string {
         $pct = $maxDuration > 0 ? min(100, round(($duration / $maxDuration) * 100)) : 0;
-        $label = formatDurationLabel($duration);
+        $label = \BBS\Core\TimeHelper::duration($duration);
         $toneClass = $status === 'failed' ? ' queue-duration-danger' : '';
         return '<div class="progress queue-duration-progress' . $toneClass . ' position-relative" title="' . htmlspecialchars($label) . '" style="--duration-pct:' . $pct . '%;">'
             . '<div class="progress-bar queue-duration-bar" style="width:' . $pct . '%;"></div>'
@@ -417,16 +413,11 @@ document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootst
                ', ' + dt.toLocaleTimeString('en-US', tOpts);
     }
 
-    function formatDuration(s) {
-        s = parseInt(s) || 0;
-        return s >= 3600 ? Math.floor(s / 3600) + 'h ' + Math.floor((s % 3600) / 60) + 'm ' + (s % 60) + 's' : (s >= 60 ? Math.floor(s / 60) + 'm ' + (s % 60) + 's' : s + 's');
-    }
-
     function durationBar(s, maxS, status) {
         s = parseInt(s) || 0;
         maxS = parseInt(maxS) || 0;
         const pct = maxS > 0 ? Math.min(100, Math.round((s / maxS) * 100)) : 0;
-        const label = formatDuration(s);
+        const label = window.BBS.formatDuration(s);
         const tone = status === 'failed' ? ' queue-duration-danger' : '';
         return '<div class="progress queue-duration-progress' + tone + ' position-relative" title="' + esc(label) + '" style="--duration-pct:' + pct + '%;">' +
             '<div class="progress-bar queue-duration-bar" style="width:' + pct + '%;"></div>' +
@@ -569,7 +560,7 @@ document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootst
             }
         }
         if (typeof data.avgSec !== 'undefined') {
-            const avgLabel = data.avgSec > 0 ? formatDuration(data.avgSec) : '--';
+            const avgLabel = data.avgSec > 0 ? window.BBS.formatDuration(data.avgSec) : '--';
             setText('qm-avg', avgLabel);
             setText('qm-avg-dur', avgLabel);
         }

--- a/src/Views/repositories/archive_detail.php
+++ b/src/Views/repositories/archive_detail.php
@@ -29,12 +29,7 @@ $statusLabels = [
 // Non-file entry types — exclude from file counts and size totals
 $nonFileStatuses = ['D', 'S', 'H', 'X', 'B', 'F', 'E'];
 
-$durLabel = '--';
-if (!empty($jobInfo['duration_seconds'])) {
-    $d = (int) $jobInfo['duration_seconds'];
-    $durLabel = $d >= 3600 ? floor($d / 3600) . 'h ' . floor(($d % 3600) / 60) . 'm'
-        : ($d >= 60 ? floor($d / 60) . 'm ' . ($d % 60) . 's' : $d . 's');
-}
+$durLabel = \BBS\Core\TimeHelper::duration((int) ($jobInfo['duration_seconds'] ?? 0));
 
 // Separate file entries from non-file entries
 $fileRows = [];

--- a/src/Views/repositories/detail.php
+++ b/src/Views/repositories/detail.php
@@ -339,8 +339,7 @@ $sizeLabel = $totalSize > 0 ? \BBS\Services\ServerStats::formatBytes((int) $tota
                                 </td>
                                 <td>
                                     <?php
-                                    $d = $job['duration_seconds'] ?? 0;
-                                    echo $d > 0 ? ($d >= 60 ? floor($d / 60) . 'm ' . ($d % 60) . 's' : $d . 's') : '--';
+                                    echo \BBS\Core\TimeHelper::duration((int) ($job['duration_seconds'] ?? 0));
                                     ?>
                                 </td>
                             </tr>

--- a/src/Views/schedules/week.php
+++ b/src/Views/schedules/week.php
@@ -953,9 +953,7 @@ function bbs_histogram_ticks(int $max): array
                         $timelineMinWidth = ((int) $b['day_idx'] === $todayIdx && $timelinePhase !== 'future' && !$timelineIsError)
                             ? '0px'
                             : null;
-                        $timelineDurLabel = $b['duration_min'] >= 60
-                            ? floor($b['duration_min'] / 60) . 'h ' . ($b['duration_min'] % 60) . 'm'
-                            : $b['duration_min'] . 'm';
+                        $timelineDurLabel = \BBS\Core\TimeHelper::duration((int) $b['duration_min'] * 60);
                         ?>
                         <div class="hist-seg hist-event is-<?= $timelinePhase ?> <?= $timelineIsError ? 'is-error' : '' ?>"
                              data-schedule-id="<?= $b['schedule_id'] ?>"
@@ -1051,9 +1049,7 @@ function bbs_histogram_ticks(int $max): array
                             $pastPct = bbs_day_block_progress_pct((int) $b['day_idx'], (int) $b['start_min'], (float) $height, $todayIdx, $currentMinuteOfDay, $pxPerHour);
                             $phase = bbs_day_block_phase($pastPct);
                             $isError = !empty($b['has_error']);
-                            $durLabel = $b['duration_min'] >= 60
-                                ? floor($b['duration_min'] / 60) . 'h ' . ($b['duration_min'] % 60) . 'm'
-                                : $b['duration_min'] . 'm';
+                            $durLabel = \BBS\Core\TimeHelper::duration((int) $b['duration_min'] * 60);
                             $title = sprintf(
                                 "%s\nClient: %s\nStarts: %s (%s)\nEstimated duration: %s%s",
                                 $b['plan_name'],


### PR DESCRIPTION
## Summary

Centralizes elapsed-duration formatting so the client status page, queue, dashboard, repository views, schedules, and API notifications all use one shared formatting path instead of local ad hoc helpers.

## What changed

- Added `TimeHelper::duration()` for server-rendered duration labels, with a small per-request cache and an optional zero-value label.
- Added `window.BBS.formatDuration()` in `public/js/app-utils.js` for live UI updates that need the same duration formatting in JavaScript.
- Wired the shared JS helper into the main app layout.
- Replaced duplicated PHP/JS duration formatting in client detail, queue pages, dashboard pages, repository views, schedule week view, and agent API notification/log messages.

## Why

The client page `Avg Duration last 30 jobs` could display durations over an hour as values like `75m 3s` instead of a compact hour-based label such as `1h 15m`. Similar formatting logic already existed in queue-related views, but it was duplicated across the site, making this kind of bug easy to reintroduce.

## Impact

Duration labels now render consistently across the app:

- `63` seconds -> `1m 3s`
- `4503` seconds -> `1h 15m`
- `90061` seconds -> `1d 1h`

UI zero durations continue to show `--`; API log contexts can still request `0s` through the shared helper.

## Validation

- `php -l` on all modified PHP files
- `node --check public/js/app-utils.js`
- Smoke-tested `TimeHelper::duration()` with `0`, `59`, `63`, `4503`, and `90061` seconds

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [x] Tested on Docker
- [x] Tested on bare metal