### PR TITLE
Restart ClickHouse when update changes config

### DIFF
--- a/bin/bbs-update-run
+++ b/bin/bbs-update-run
@@ -45,11 +45,25 @@ echo "[5/9] Checking ClickHouse..."
 if command -v clickhouse-server &>/dev/null; then
     # Ensure config override is in place
     mkdir -p /etc/clickhouse-server/config.d
+    CH_OVERRIDE_CHANGED=0
+    CH_OVERRIDE_SRC="$BBS_DIR/config/clickhouse-server-override.xml"
+    CH_OVERRIDE_DST="/etc/clickhouse-server/config.d/bbs-override.xml"
     if [ -f "$BBS_DIR/config/clickhouse-server-override.xml" ]; then
-        cp "$BBS_DIR/config/clickhouse-server-override.xml" /etc/clickhouse-server/config.d/bbs-override.xml
+        if ! cmp -s "$CH_OVERRIDE_SRC" "$CH_OVERRIDE_DST"; then
+            cp "$CH_OVERRIDE_SRC" "$CH_OVERRIDE_DST"
+            CH_OVERRIDE_CHANGED=1
+        fi
     fi
     # Ensure service is running
-    systemctl is-active --quiet clickhouse-server || systemctl start clickhouse-server 2>/dev/null || true
+    if systemctl is-active --quiet clickhouse-server; then
+        if [ "$CH_OVERRIDE_CHANGED" -eq 1 ]; then
+            systemctl restart clickhouse-server 2>/dev/null || true
+            sleep 2
+        fi
+    else
+        systemctl start clickhouse-server 2>/dev/null || true
+        sleep 2
+    fi
     # Ensure database and tables exist (idempotent)
     clickhouse-client --query "CREATE DATABASE IF NOT EXISTS bbs" 2>/dev/null || true
     clickhouse-client -d bbs --multiquery < "$BBS_DIR/schema-clickhouse.sql" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes the bare-metal update path so ClickHouse is restarted when the BBS ClickHouse override config changes during an update.

## Bug

On the test server, `systemd-journald` was burning CPU because it was suppressing roughly 3.5 million messages from `clickhouse-server.service` every 30 seconds. The repeated ClickHouse messages were `Cannot log message in OwnAsyncSplitChannel` with `File access error` for `/var/log/clickhouse-server/clickhouse-server.log` and `.err.log`.

The installed `/etc/clickhouse-server/config.d/bbs-override.xml` had the intended low-noise logger settings, but the running ClickHouse process had started before that file was updated. That means the updater had copied the new config to disk without applying it to the live service.

## Root Cause

`bin/bbs-install` already restarts ClickHouse after installing `bbs-override.xml`, but `bin/bbs-update-run` only copied the override and then started ClickHouse if it was inactive. For an already-running service, config changes stayed unapplied until a manual restart or reboot.

This made the issue recur after updates that changed the ClickHouse override: the file on disk looked correct, while the running process still used the previous logging behavior.

## Changes

- Track whether `config/clickhouse-server-override.xml` differs from `/etc/clickhouse-server/config.d/bbs-override.xml`.
- Copy the override only when it changed.
- Restart an active `clickhouse-server` when the override changed so the new logger/system-log settings are applied.
- Preserve the existing behavior of starting ClickHouse when it is not active.

## Validation

- Ran `bash -n bin/bbs-update-run`.
- Ran `git diff --check -- bin/bbs-update-run`.

## Testing

<!-- How was this tested? Docker, bare metal, or both? -->

- [] Tested on bare metal