### PR TITLE
Update index.php S3 Sync Backup Text

### DIFF
--- a/src/Views/storage-locations/index.php
+++ b/src/Views/storage-locations/index.php
@@ -136,7 +136,7 @@ function escapeHtml(value) {
                         <label class="form-check-label" for="s3_sync_server_backups">
                             Sync server backups to off-site storage daily
                         </label>
-                        <div class="form-text">Uploads the 7 most recent server backups from <code>/var/bbs/backups/</code> and removes older ones from S3.</div>
+                        <div class="form-text">Uploads the server backups from <code>/var/bbs/backups/</code> and removes deleted ones from S3.</div>
                     </div>
 
                     <div class="d-flex gap-2">


### PR DESCRIPTION
Fix incorrect/outdated text stating only 7 days of backups were synced. It's a configurable value in settings now.

## Summary

The "Sync server backups to off-site storage daily" checkbox's description states the 7 most recent backups are synced to the S3 bucket. I don't know what the history on this is, but it's currently a configurable number elsewhere in settings. For example, I have my server set to 14, and my S3 bucket does indeed have 14 server backups in it.

Since that's how I would expect things to behave, that makes the hardcoded 7 in the message a typo. 
 

## Changes


- Changed message to "Uploads the server backups from <code>/var/bbs/backups/</code> and removes deleted ones from S3."

## Testing

Currently untested. Wanted to get your feedback and any comments/requests before I go through the effort of building my own local docker image and testing.
