### PR TITLE
Fix PostgreSQL "Databases = *" enumeration: query pg_database instead of parsing psql -l

### DIFF
--- a/agent/bbs-agent.py
+++ b/agent/bbs-agent.py
@@ -1699,19 +1699,21 @@ def execute_plugin_pg_dump(config):
     pg_env["PGPASSWORD"] = password
 
     if isinstance(databases, str) and databases.strip() == "*":
-        # List all databases via psql
-        list_cmd = ["psql", "-h", host, "-p", port, "-U", user, "-l", "-t", "-A"]
+        # List databases via a catalog query. Parsing `psql -l` is unsafe: DBs with
+        # GRANTed privileges have a multi-line "Access privileges" column whose
+        # continuation lines (e.g. "<grantee>=<privs>/<grantor>") get mis-parsed as names.
+        list_cmd = ["psql", "-h", host, "-p", port, "-U", user, "-tAc",
+                    "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate"]
         result = subprocess.run(list_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=pg_env)
         if result.returncode != 0:
             raise Exception("Failed to list databases: {}".format(result.stderr.decode('utf-8', errors='replace').strip()))
         if isinstance(exclude, str):
             exclude = [x.strip() for x in exclude.split(",")]
-        # psql -l -t -A outputs: dbname|owner|encoding|collate|ctype|access
         databases = []
         for line in result.stdout.decode("utf-8", errors="replace").strip().split("\n"):
-            parts = line.split("|")
-            if parts and parts[0].strip() and parts[0].strip() not in exclude:
-                databases.append(parts[0].strip())
+            name = line.strip()
+            if name and name not in exclude:
+                databases.append(name)
     elif isinstance(databases, str):
         databases = [d.strip() for d in databases.split(",") if d.strip()]
 
@@ -1798,13 +1800,14 @@ def test_plugin_pg_dump(config):
         raise Exception("Connection failed: {}".format(result.stderr.decode('utf-8', errors='replace').strip()))
 
     # List databases
-    cmd2 = ["psql", "-h", host, "-p", port, "-U", user, "-l", "-t", "-A"]
+    cmd2 = ["psql", "-h", host, "-p", port, "-U", user, "-tAc",
+            "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate"]
     result2 = subprocess.run(cmd2, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=pg_env, timeout=15)
     dbs = []
     for line in result2.stdout.decode("utf-8", errors="replace").strip().split("\n"):
-        parts = line.split("|")
-        if parts and parts[0].strip():
-            dbs.append(parts[0].strip())
+        name = line.strip()
+        if name:
+            dbs.append(name)
     return "Connection successful. Found {} database(s): {}".format(len(dbs), ', '.join(dbs[:10]))
 
 


### PR DESCRIPTION
## What & why
The PostgreSQL backup plugin fails on any cluster that has databases with GRANTed privileges when `Databases = *` is used. This PR replaces the fragile `psql -l` text parsing with a catalog query.

## Problem
With `Databases = *`, the agent enumerates databases by parsing `psql -l -t -A` and taking `line.split("|")[0]`. For databases with non-default ACLs (GRANTs), the *Access privileges* column is **multi-line**. `psql -l -t -A` emits those continuation lines, and they contain no `|` — they look like `<grantee>=<privileges>/<grantor>`. Each such line is mistaken for a database name, so the dump writes to an invalid path and the backup fails:

```
Pre-backup plugin failed: [Errno 2] No such file or directory:
'<dump_dir>/<grantee>=<privileges>/<grantor>.sql'
```

## Root cause
`psql -l -t -A` for a database with a grant produces:
```
<db>|<owner>|UTF8|...|=<privs>/<owner>
<grantee>=<privs>/<grantor>        # continuation line, no "|", mis-read as a db name
```

## Fix
Enumerate via `SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate`, which returns exactly one database name per line and is immune to ACL formatting. Applied in both `execute_plugin_pg_dump` (backup enumeration) and `test_plugin_pg_dump` (connection-test listing).

## Testing
Verified against a PostgreSQL 17 cluster whose databases have GRANTed privileges:
- **Before:** `psql -l -t -A` yields extra lines like `<grantee>=<privs>/<grantor>` → backup fails with the path error above.
- **After:** the catalog query returns a clean one-name-per-line list; backup enumerates only real databases.

Template databases are excluded via `NOT datistemplate`; the plugin's existing `exclude_databases` filter still applies.

## Environment
BBS server v2.62.0, agent v2.61.0, PostgreSQL 17.
