### PR TITLE
Server Health: report memory as unavailable instead of zero (#485)

### DIFF
--- a/src/Controllers/Api/AdminApiController.php
+++ b/src/Controllers/Api/AdminApiController.php
@@ -2624,10 +2624,14 @@ class AdminApiController extends Controller
                 'load_1min' => (float) ($cpu['1min'] ?? 0),
                 'cores' => (int) ($cpu['cores'] ?? 1),
             ],
+            // null rather than 0 when memory cannot be read at all, same rule
+            // as network below: no machine has 0 bytes of RAM, so zeros could
+            // only ever mean a failed read — and they render as a believable
+            // empty gauge (#485).
             'memory' => [
-                'percent' => (float) ($mem['percent'] ?? 0),
-                'used_bytes' => (int) ($mem['used'] ?? 0),
-                'total_bytes' => (int) ($mem['total'] ?? 0),
+                'percent' => $mem ? (float) $mem['percent'] : null,
+                'used_bytes' => $mem ? (int) $mem['used'] : null,
+                'total_bytes' => $mem ? (int) $mem['total'] : null,
             ],
             // null rather than 0 when throughput cannot be read at all, so
             // "idle" and "unavailable" stay distinguishable.

--- a/src/Controllers/DashboardController.php
+++ b/src/Controllers/DashboardController.php
@@ -302,12 +302,12 @@ class DashboardController extends Controller
                 '1min' => $cpu['1min'] ?? 0,
                 'cores' => $cpu['cores'] ?? 1,
             ],
-            'memory' => [
-                'percent' => $mem['percent'] ?? 0,
-                'used_label' => ServerStats::formatBytes($mem['used'] ?? 0),
-                'total_label' => ServerStats::formatBytes($mem['total'] ?? 0),
-                'pair_label' => ServerStats::formatBytesPair((int) ($mem['used'] ?? 0), (int) ($mem['total'] ?? 0)),
-            ],
+            'memory' => $mem ? [
+                'percent' => $mem['percent'],
+                'used_label' => ServerStats::formatBytes($mem['used']),
+                'total_label' => ServerStats::formatBytes($mem['total']),
+                'pair_label' => ServerStats::formatBytesPair((int) $mem['used'], (int) $mem['total']),
+            ] : null,
             'net' => $net ? [
                 'rx_bps' => $net['rx_bps'],
                 'tx_bps' => $net['tx_bps'],

--- a/src/Services/ServerStats.php
+++ b/src/Services/ServerStats.php
@@ -63,9 +63,17 @@ class ServerStats
     }
 
     /**
-     * Get memory usage.
+     * Get memory usage, or null when it cannot be measured at all.
+     *
+     * null rather than zeros, for the same reason getNetworkThroughput()
+     * returns null: no machine has 0 bytes of RAM, so zeros could only ever
+     * mean a failed read — but they render as a perfectly plausible empty
+     * gauge and nothing is logged. A hardened apache2.service with
+     * ProcSubset=pid hid /proc/meminfo from the service and produced exactly
+     * that, while CPU kept working through the sys_getloadavg() fallback, so
+     * the card looked merely idle (#485).
      */
-    public static function getMemory(): array
+    public static function getMemory(): ?array
     {
         if (PHP_OS_FAMILY === 'Darwin') {
             return self::getMemoryMac();
@@ -73,11 +81,22 @@ class ServerStats
         return self::getMemoryLinux();
     }
 
-    private static function getMemoryLinux(): array
+    private static function getMemoryLinux(): ?array
     {
         $meminfo = @file_get_contents('/proc/meminfo');
         if ($meminfo === false) {
-            return ['total' => 0, 'used' => 0, 'free' => 0, 'percent' => 0];
+            // Logged rather than silently swallowed: this is the only trace an
+            // operator gets that the gauge is broken rather than the machine
+            // idle. Once per worker, not once per request — Cache::remember()
+            // treats a null result as a miss, so this path runs on every poll
+            // and would otherwise flood the error log.
+            static $warned = false;
+            if (!$warned) {
+                $warned = true;
+                error_log('ServerStats: /proc/meminfo is unreadable — memory metrics unavailable. '
+                    . 'On a hardened apache2.service this is ProcSubset=pid hiding /proc.');
+            }
+            return null;
         }
 
         $values = [];
@@ -87,7 +106,12 @@ class ServerStats
             }
         }
 
+        // A /proc/meminfo that parsed but carries no MemTotal is not a machine
+        // with no RAM either — same reasoning, same null.
         $total = $values['MemTotal'] ?? 0;
+        if ($total <= 0) {
+            return null;
+        }
         $available = $values['MemAvailable'] ?? ($values['MemFree'] ?? 0);
         $used = $total - $available;
 
@@ -95,7 +119,7 @@ class ServerStats
             'total' => $total,
             'used' => $used,
             'free' => $available,
-            'percent' => $total > 0 ? round(($used / $total) * 100, 1) : 0,
+            'percent' => round(($used / $total) * 100, 1),
         ];
     }
 

--- a/src/Views/dashboard/index.php
+++ b/src/Views/dashboard/index.php
@@ -555,9 +555,13 @@ $dfFix = function (string $s): string {
                 <div class="card-body">
                     <?php
                         $cpuPct = (float) ($cpuLoad['percent'] ?? 0);
-                        $memPct = (float) ($memory['percent'] ?? 0);
-                        $memUsed = (int) ($memory['used'] ?? 0);
-                        $memTotal = (int) ($memory['total'] ?? 0);
+                        // getMemory() returns null, not zeros, when /proc/meminfo
+                        // cannot be read — the gauge must say so rather than
+                        // draw a plausible empty bar (#485).
+                        $memOk    = is_array($memory);
+                        $memPct   = $memOk ? (float) $memory['percent'] : 0.0;
+                        $memUsed  = $memOk ? (int) $memory['used'] : 0;
+                        $memTotal = $memOk ? (int) $memory['total'] : 0;
                         $cpuColor = $cpuPct > 80 ? '#ef4444' : ($cpuPct > 50 ? '#f59e0b' : '#22c55e');
                         $cpuStatus = $cpuPct > 80 ? 'High Usage' : ($cpuPct > 50 ? 'Moderate' : 'Healthy');
                         $memColor = $memPct > 85 ? '#ef4444' : ($memPct > 60 ? '#f59e0b' : '#0dcaf0');
@@ -606,7 +610,8 @@ $dfFix = function (string $s): string {
 
                         $arcLen    = 251.33;                              // π × radius 80, semicircle
                         $cpuOffset = $arcLen * (1 - $cpuPct / 100);
-                        $memPair   = ServerStats::formatBytesPair($memUsed, $memTotal);
+                        $memPair   = $memOk ? ServerStats::formatBytesPair($memUsed, $memTotal)
+                                            : 'unavailable';
 
                         // Network meter initial labels. First page load after a
                         // cold cache has no rate yet ("—"); the 15s poll fills it.
@@ -638,7 +643,9 @@ $dfFix = function (string $s): string {
                                 <div class="cpu-pct"><span id="cpu-pct-num"><?= round($cpuPct, 1) ?></span><span class="pct-suffix">%</span></div>
                                 <div class="cpu-status" id="cpu-status" style="color: <?= $cpuColor ?>"><?= $cpuStatus ?></div>
                             </div>
-                            <div class="cpu-mem-row" title="Memory: <?= round($memPct, 1) ?>% used">
+                            <div class="cpu-mem-row" title="<?= $memOk
+                                    ? 'Memory: ' . round($memPct, 1) . '% used'
+                                    : 'Memory unavailable — /proc/meminfo could not be read' ?>">
                                 <div class="cm-bar">
                                     <div id="mem-bar-fill" class="cm-bar-fill" style="width: <?= $memPct ?>%; background-color: <?= $memColor ?>;"></div>
                                     <span class="cm-bar-label"><span id="mem-pct"><?= round($memPct, 1) ?></span>%</span>
@@ -1270,7 +1277,13 @@ document.addEventListener('DOMContentLoaded', function () {
                     if (cpuStatus) { cpuStatus.textContent = status; cpuStatus.style.color = color; }
                 }
 
-                if (d.memory && memFill) {
+                if (d.memory === null && memSizeEl) {
+                    // Explicit null: the server could not read /proc/meminfo.
+                    // Leaving the last value on screen would pass for a live one.
+                    memSizeEl.textContent = 'unavailable';
+                    if (memFill) memFill.style.width = '0%';
+                    if (memPctEl) memPctEl.textContent = '0';
+                } else if (d.memory && memFill) {
                     const p = Number(d.memory.percent) || 0;
                     memFill.style.width = p + '%';
                     memFill.style.backgroundColor = memPalette(p);


### PR DESCRIPTION
Follow-up to #485, as asked — the drop-in fix is already on main, this is only the "make the failure visible" half.

## What it changes

`getMemory()` returned `['total' => 0, 'used' => 0, 'free' => 0, 'percent' => 0]` when `/proc/meminfo` could not be read. That is indistinguishable from a machine with no RAM, renders as a perfectly plausible empty gauge, and logs nothing — which is exactly how the hardened apache2 unit hid the failure for us: CPU kept answering through the `sys_getloadavg()` fallback, so the card just looked idle.

Ten lines below, in the same handler, `network` already had the right shape. This applies the same rule to memory.

- `getMemory(): ?array` — `null` on a failed read, and also on a `/proc/meminfo` that parses but carries no `MemTotal`, which is not a machine with no RAM either.
- One `error_log` line, guarded by a `static` so it fires once per worker rather than once per request. `Cache::remember()` treats a `null` result as a miss, so on a broken host this path runs on every poll and would otherwise flood the log.
- `/api/v1/server-stats` propagates `null` on `percent` / `used_bytes` / `total_bytes`, exactly as `network` does for `rx` / `tx`.
- `/dashboard/health-json` returns `memory: null`, and the poller writes "unavailable" instead of leaving the last value on screen — a stale number would pass for a live reading.
- The Server Health card renders `unavailable` rather than `0 B / 0 B`.

All three `getMemory()` callers are updated (`DashboardController` ×2, `AdminApiController`); `grep` finds no others.

## Testing

Linted on `php:8.3-cli`, and the three paths exercised for real:

| Case | Result |
|---|---|
| normal `/proc/meminfo` | `array total=50429984768 percent=44.7` |
| `/proc/meminfo` readable but without `MemTotal` | `NULL` |
| read refused (`open_basedir`) | `NULL`, preceded by the log line, once |

Bare metal only — I have not exercised this on a Docker install.

## The one thing that is your call

`memory.percent` / `used_bytes` / `total_bytes` becoming nullable is a shape change for anything consuming `/api/v1/server-stats`. It matches what `network` already does, and you said null is the right shape, but it is a change worth naming in the release notes.
