### PR TITLE
Fix custom branding favicons not serving in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN pip3 install --break-system-packages --no-cache-dir apprise wheel>=0.46.2 &&
     rm -rf /root/.cache /usr/lib/python3/dist-packages/wheel*
 
 # Install PHP extensions
-RUN docker-php-ext-install pdo pdo_mysql mbstring
+RUN docker-php-ext-install pdo pdo_mysql mbstring gd
 
 # PHP configuration: increase max_execution_time (default 30s is too short for
 # large backup operations, catalog imports, and API calls under load).


### PR DESCRIPTION
## Summary

Branding Controller's GD-based icon resize silently failed because php-gd was never installed in the Docker image, so custom app icons always fell back to the bundled default. 

## Changes

- Add `gd` to `docker-php-ext-install` in Dockerfile

## Testing

- Verified `/branding/icon/512` (and other sizes) returned bundled default before fix.
- Verified `/branding/icon/512` (and other sizes) returns correctly resized, user-supplied icons.
- Verified resized icons are cached to `/var/bbs/cache/branding`

- [x] Tested on Docker
- [ ] Tested on bare metal
- [ ] Agent changes tested on Linux
- [ ] Agent changes tested on Windows
